### PR TITLE
Report failure to find git

### DIFF
--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -103,9 +103,13 @@ export function run(outChannel: vscode.OutputChannel): any {
 	}
 
 	function genericErrorHandler(error) {
-		outChannel.append(error);
-		outChannel.show();
-		vscode.window.showErrorMessage("There was an error, please view details in output log");
+        if (error.code && error.syscall && error.code === 'ENOENT' && error.syscall === 'spawn git') {
+            vscode.window.showErrorMessage("Cannot find the git installation");
+        } else {
+            outChannel.appendLine(error);
+            outChannel.show();
+            vscode.window.showErrorMessage("There was an error, please view details in output log");
+        }
 	}
 
 	function launchFileCompareWithPrevious(details) {

--- a/src/commands/lineHistory.ts
+++ b/src/commands/lineHistory.ts
@@ -61,9 +61,13 @@ export function run(outChannel: vscode.OutputChannel): any {
 	}
 
 	function genericErrorHandler(error) {
-		outChannel.appendLine("error:" + error);
-		outChannel.show();
-		vscode.window.showErrorMessage("There was an error, please view details in output log");
+        if (error.code && error.syscall && error.code === 'ENOENT' && error.syscall === 'spawn git') {
+            vscode.window.showErrorMessage("Cannot find the git installation");
+        } else {
+            outChannel.appendLine(error);
+            outChannel.show();
+            vscode.window.showErrorMessage("There was an error, please view details in output log");
+        }
 	}
 }
 

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -28,6 +28,10 @@ export function getFileHistory(rootDir: string, relativeFilePath: string): Thena
 			var parsedLog = parser.parseLogContents(log);
 			resolve(parsedLog);
 		});
+        
+        ls.on('error', function(error) {
+            reject(error);
+        });
 	});
 }
 
@@ -58,6 +62,10 @@ export function getLineHistory(rootDir: string, relativeFilePath: string, lineNu
 			var parsedLog = parser.parseLogContents(log);
 			resolve(parsedLog);
 		});
+        
+        ls.on('error', function(error) {
+            reject(error);
+        });
 	});
 }
 


### PR DESCRIPTION
The git history plugin expects the git executable to be found in the PATH. Git for Windows, however, explicitly recommends *not* to add it to the PATH environment variable in its installer.
This change will report errors that occur when the git executable cannot be found to the user.