### PR TITLE
Find Git for Windows installations

### DIFF
--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -103,9 +103,13 @@ export function run(outChannel: vscode.OutputChannel): any {
 	}
 
 	function genericErrorHandler(error) {
-		outChannel.append(error);
-		outChannel.show();
-		vscode.window.showErrorMessage("There was an error, please view details in output log");
+        if (error.code && error.syscall && error.code === 'ENOENT' && error.syscall === 'spawn git') {
+            vscode.window.showErrorMessage("Cannot find the git installation");
+        } else {
+            outChannel.appendLine(error);
+            outChannel.show();
+            vscode.window.showErrorMessage("There was an error, please view details in output log");
+        }
 	}
 
 	function launchFileCompareWithPrevious(details) {

--- a/src/commands/lineHistory.ts
+++ b/src/commands/lineHistory.ts
@@ -61,9 +61,13 @@ export function run(outChannel: vscode.OutputChannel): any {
 	}
 
 	function genericErrorHandler(error) {
-		outChannel.appendLine("error:" + error);
-		outChannel.show();
-		vscode.window.showErrorMessage("There was an error, please view details in output log");
+        if (error.code && error.syscall && error.code === 'ENOENT' && error.syscall === 'spawn git') {
+            vscode.window.showErrorMessage("Cannot find the git installation");
+        } else {
+            outChannel.appendLine(error);
+            outChannel.show();
+            vscode.window.showErrorMessage("There was an error, please view details in output log");
+        }
 	}
 }
 

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -1,98 +1,174 @@
 import * as vscode from 'vscode';
 import * as parser from '../logParser';
 import * as fs from 'fs';
+import { exec, spawn } from 'child_process';
 
-export function getFileHistory(rootDir: string, relativeFilePath: string): Thenable<any[]> {
-	return new Promise<any[]>((resolve, reject) => {
-		var options = { cwd: rootDir }
-		var util = require('util'),
-			spawn = require('child_process').spawn,
-			ls = spawn('git', ['log', '--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', relativeFilePath], options);
 
-		var log = "";
-		var error = "";
-		ls.stdout.on('data', function(data) {
-			log += data + "\n";
-		});
+function getGitExecutable(): Promise<string> {
+    return new Promise((resolve, reject) => {
+        if (process.platform !== 'win32') {
+            // Default: search in PATH environment variable
+            resolve('git');
+        } else {
+            // in Git for Windows, the recommendation is not to put git into the PATH.
+            // Instead, there is an entry in the Registry.
+            
+            let regQueryInstallPath: (location: string, view: string) => Promise<string> = (location, view) => {
+                return new Promise((resolve, reject) => {
+                    let callback = function(error, stdout, stderr) {
+                        if (error && error.code !== 0) {
+                            error.stdout = stdout.toString();
+                            error.stderr = stderr.toString();
+                            reject(error);
+                            return;
+                        }
 
-		ls.stderr.on('data', function(data) {
-			error += data;
-		});
+                        var installPath = stdout.toString().match(/InstallPath\s+REG_SZ\s+([^\r\n]+)\s*\r?\n/i)[1];
+                        if (installPath) {
+                            resolve(installPath + '\\bin\\git');
+                        } else {
+                            reject();
+                        }
+                    };
 
-		ls.on('exit', function(code) {
-			if (error.length > 0) {
-				reject(error);
-				return;
-			}
+                    let viewArg = '';
+                    switch (view) {
+                        case '64': viewArg = '/reg:64'; break;
+                        case '32': viewArg = '/reg:64'; break;
+                        default: break;
+                    }
 
-			var parsedLog = parser.parseLogContents(log);
-			resolve(parsedLog);
-		});
-        
-        ls.on('error', function(error) {
-            reject(error);
-        });
-	});
+                    exec('reg query ' + location + ' ' + viewArg, callback);
+                });
+            };
+
+            let queryChained: (locations: { key: string, view: string }[]) => Promise<string> = (locations) => {
+                return new Promise<string>((resolve, reject) => {
+                    if (locations.length === 0) {
+                        reject('None of the known git Registry keys were found');
+                        return;
+                    }
+
+                    let location = locations[0];
+                    regQueryInstallPath(location.key, location.view).then(
+                        (location) => resolve(location),
+                        (error) => queryChained(locations.slice(1)).then(
+                            (location) => resolve(location),
+                            (error) => reject(error)
+                        )
+                    );
+                });
+            };
+
+            queryChained([
+                { 'key': 'HKCU\\SOFTWARE\\GitForWindows', 'view': null },   // user keys have precendence over
+                { 'key': 'HKLM\\SOFTWARE\\GitForWindows', 'view': null },   // machine keys
+                { 'key': 'HKCU\\SOFTWARE\\GitForWindows', 'view': '64' },   // default view (null) before 64bit view
+                { 'key': 'HKLM\\SOFTWARE\\GitForWindows', 'view': '64' },
+                { 'key': 'HKCU\\SOFTWARE\\GitForWindows', 'view': '32' },   // last is 32bit view, which will only be checked
+                { 'key': 'HKLM\\SOFTWARE\\GitForWindows', 'view': '32' }]). // for a 32bit git installation on 64bit Windows
+                then(
+                    (path) => resolve(path),
+                    // fallback: PATH
+                    (error) => resolve('git')
+                );
+        }
+    })
+}
+
+export function getFileHistory(rootDir, relativeFilePath): Promise<any[]> {
+    return getGitExecutable().then(
+        (gitExecutable) => new Promise((resolve, reject) => {
+            var options = { cwd: rootDir };
+            var ls = spawn(gitExecutable,
+                ['log', '--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', relativeFilePath],
+                options);
+
+            var log = "";
+            var error = "";
+            ls.stdout.on('data', function(data) {
+                log += data + "\n";
+            });
+            
+            ls.stderr.on('data', function(data) {
+                error += data;
+            });
+            
+            ls.on('exit', function(code) {
+                if (error.length > 0) {
+                    reject(error);
+                    return;
+                }
+                
+                var parsedLog = parser.parseLogContents(log);
+                resolve(parsedLog);
+            });
+
+            ls.on('error', function(error) {
+                reject(error);
+            });
+        }));
 }
 
 export function getLineHistory(rootDir: string, relativeFilePath: string, lineNumber: number): Thenable<any[]> {
-	return new Promise<any[]>((resolve, reject) => {
-		var options = { cwd: rootDir }
-		var lineArgs = "-L" + lineNumber + "," + lineNumber + ":" + relativeFilePath.replace(/\\/g, '/');
-		var util = require('util'),
-			spawn = require('child_process').spawn,
-			ls = spawn('git', ['log', lineArgs, '--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--numstat', '--topo-order', '--raw'], options);
+    return getGitExecutable().then(
+        (gitExecutable) => new Promise<any[]>((resolve, reject) => {
+            var options = { cwd: rootDir }
+            var lineArgs = "-L" + lineNumber + "," + lineNumber + ":" + relativeFilePath.replace(/\\/g, '/');
+            var ls = spawn(gitExecutable,
+                ['log', lineArgs, '--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--numstat', '--topo-order', '--raw'],
+                options);
 
-		var log = "";
-		var error = "";
-		ls.stdout.on('data', function(data) {
-			log += data + "\n";
-		});
+            var log = "";
+            var error = "";
+            ls.stdout.on('data', function(data) {
+                log += data + "\n";
+            });
 
-		ls.stderr.on('data', function(data) {
-			error += data;
-		});
+            ls.stderr.on('data', function(data) {
+                error += data;
+            });
 
-		ls.on('exit', function(code) {
-			if (error.length > 0) {
-				reject(error);
-				return;
-			}
+            ls.on('exit', function(code) {
+                if (error.length > 0) {
+                    reject(error);
+                    return;
+                }
 
-			var parsedLog = parser.parseLogContents(log);
-			resolve(parsedLog);
-		});
-        
-        ls.on('error', function(error) {
-            reject(error);
-        });
-	});
+                var parsedLog = parser.parseLogContents(log);
+                resolve(parsedLog);
+            });
+
+            ls.on('error', function(error) {
+                reject(error);
+            });
+        }));
 }
 
 export function writeFile(rootDir: string, commitSha1: string, sourceFilePath: string, targetFile: string): Thenable<any> {
-	return new Promise<any>((resolve, reject) => {
-		var options = { cwd: rootDir }
-		var objectId = `${commitSha1}:` + sourceFilePath.replace(/\\/g, '/');
-		var spawn = require('child_process').spawn,
-			ls = spawn('git', ['show', objectId], options);
+    return getGitExecutable().then(
+        (gitExecutable) => new Promise<any>((resolve, reject) => {
+            var options = { cwd: rootDir }
+            var objectId = `${commitSha1}:` + sourceFilePath.replace(/\\/g, '/');
+            var ls = spawn(gitExecutable, ['show', objectId], options);
 
-		var log = "";
-		var error = "";
-		ls.stdout.on('data', function(data) {
-			fs.appendFile(targetFile, data);
-		});
+            var log = "";
+            var error = "";
+            ls.stdout.on('data', function(data) {
+                fs.appendFile(targetFile, data);
+            });
 
-		ls.stderr.on('data', function(data) {
-			error += data;
-		});
+            ls.stderr.on('data', function(data) {
+                error += data;
+            });
 
-		ls.on('exit', function(code) {
-			if (error.length > 0) {
-				reject(error);
-				return;
-			}
+            ls.on('exit', function(code) {
+                if (error.length > 0) {
+                    reject(error);
+                    return;
+                }
 
-			resolve(targetFile);
-		});
-	});
+                resolve(targetFile);
+            });
+        }));
 }

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -28,6 +28,10 @@ export function getFileHistory(rootDir: string, relativeFilePath: string): Thena
 			var parsedLog = parser.parseLogContents(log);
 			resolve(parsedLog);
 		});
+        
+        ls.on('error', function(error) {
+            reject(error);
+        });
 	});
 }
 
@@ -58,6 +62,10 @@ export function getLineHistory(rootDir: string, relativeFilePath: string, lineNu
 			var parsedLog = parser.parseLogContents(log);
 			resolve(parsedLog);
 		});
+        
+        ls.on('error', function(error) {
+            reject(error);
+        });
 	});
 }
 


### PR DESCRIPTION
Git for Windows's installer recommends not to put the git executables into the PATH environment variable. Therefore, 'git' will not be found when executed. The installer stores git's location in a registry key, however. This change will evaluate the registry on Windows systems and tries to find the full path to git.