### PR TITLE
make sure getGitRepositoryPath return an absolute path

### DIFF
--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -36,7 +36,10 @@ export function getGitRepositoryPath(fileName: string): Thenable<string> {
 				reject(error);
 				return;
 			}
-            resolve(path.dirname(log));
+			var repositoryPath = path.dirname(log);
+			if (!path.isAbsolute(repositoryPath))
+				repositoryPath = path.join(path.dirname(fileName), repositoryPath);
+			resolve(repositoryPath);
 		});
     });
 }


### PR DESCRIPTION
fix an issue when ‘—git-path’ return ‘.git’