### PR TITLE
Making View File History only show commits from the current branch

### DIFF
--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -116,7 +116,7 @@ export function getGitRepositoryPath(fileName: string): Thenable<string> {
 }
 
 export function getFileHistory(rootDir: string, relativeFilePath: string): Thenable<any[]> {
-    return getLog(rootDir, relativeFilePath, ['--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', relativeFilePath]);
+    return getLog(rootDir, relativeFilePath, ['--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--parents', '--numstat', '--topo-order', '--raw', '--follow', relativeFilePath]);
 }
 export function getFileHistoryBefore(rootDir: string, relativeFilePath: string, sha1: string, isoStrictDateTime: string): Thenable<any[]> {
     return getLog(rootDir, relativeFilePath, [`--max-count=10`, '--decorate=full', '--date=local', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', `--before='${isoStrictDateTime}'`, relativeFilePath]);


### PR DESCRIPTION
Currently, the **View File History** option shows commits from all branches.

This is an inconvienient default, especially for projects with many contributors, because what it may end up outputting are commits that were  never a part of the edited file's history.

It was also inconsistent with **View History** and **View Line History** options provided by the plugin, which only show the history from the current branch.
