### PR TITLE
Swap diff assume workspace is latest.

### DIFF
--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -193,6 +193,6 @@ function displayFile(commitSha1: string, localFilePath: string): Thenable<string
 
 function compareFileWithLocalCopy(commitSha1: string, localFilePath: string, relativeFilePath: string): Thenable<string> {
 	return getFile(commitSha1, relativeFilePath).then((tmpFilePath) => {
-		return vscode.commands.executeCommand("vscode.diff", vscode.Uri.file(localFilePath), vscode.Uri.file(tmpFilePath));
+		return vscode.commands.executeCommand("vscode.diff", vscode.Uri.file(tmpFilePath), vscode.Uri.file(localFilePath));
 	});
 }


### PR DESCRIPTION
Most common senario is workspace is newer than another commit version.
Fixes #8