### PR TITLE
Fix async overwrites.

### DIFF
--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -199,7 +199,7 @@ export function writeFile(rootDir: string, commitSha1: string, sourceFilePath: s
             var log = "";
             var error = "";
             ls.stdout.on('data', function (data) {
-                fs.appendFile(targetFile, data);
+                fs.appendFileSync(targetFile, data);
             });
 
             ls.stderr.on('data', function (data) {


### PR DESCRIPTION
Fixes #56.
An async strategy may be preferable in the future.
I couldn't detect a difference in performance from the async version however.
This provides a simple fix until a more complex (risky) async fix is developed.