### PR TITLE
Fix compile error due to @types/clipboard update.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "@types/clipboard": "^1.5.28",
+    "@types/clipboard": "^1.5.30",
     "typescript": "^1.7.5",
     "vscode": "^0.11.0"
   },

--- a/src/browser/proxy.ts
+++ b/src/browser/proxy.ts
@@ -1,4 +1,5 @@
 /// <reference path="typings/types.d.ts" />
+import * as Clipboard from 'clipboard';
 
 (function () {
     (window as any).GITHISTORY = {};


### PR DESCRIPTION
The above package was updated to a CJS module in 1.5.30.
This now requires an imports statement to use the module
Fixes #60.
Note existing local Repos will need to do an npm install to update their packages.