### PR TITLE
Fix compile error due to @types/clipboard update.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "@types/clipboard": "^1.5.28",
+    "@types/clipboard": "1.5.29",
     "typescript": "^1.7.5",
     "vscode": "^0.11.0"
   },


### PR DESCRIPTION
Fixes #60.
The above package was updated to a CJS module in 1.5.30.
Fix the package version to 1.5.29.
Note existing local Repos will need to do an npm install to downgrade their package if 1.5.30 is present.

Note I tried to integrate the 1.5.30 but it broke some of the click handling so this seems safer.
Using 1.5.30 will require some redesign.