### PR TITLE
Command viewFileCommitDetails uses author date.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "@types/clipboard": "^1.5.28",
+    "@types/clipboard": "1.5.29",
     "typescript": "^1.7.5",
     "vscode": "^0.11.0"
   },
@@ -88,7 +88,7 @@
     "clipboard": "^1.5.12",
     "htmlencode": "0.0.4",
     "jquery": "^3.1.0",
-    "moment": "^2.14.1",
+    "moment": "2.14.1",
     "normalize.css": "^4.2.0",
     "tmp": "0.0.28"
   }

--- a/src/browser/detailsView.ts
+++ b/src/browser/detailsView.ts
@@ -86,7 +86,7 @@ import * as contracts from '../contracts';
                 }
             });
             $('.file-name', $fileItem).html(stat.path);
-            let uri = encodeURI('command:git.viewFileCommitDetails?' + JSON.stringify([entry.sha1.full, stat.path, moment(entry.author.date).format('YYYY-MM-DD HH:mm:ss ZZ')]))
+            let uri = encodeURI('command:git.viewFileCommitDetails?' + JSON.stringify([entry.sha1.full, stat.path, moment(entry.committer.date).format('YYYY-MM-DD HH:mm:ss ZZ')]))
             $('.file-name', $fileItem).attr('href', uri);
             $files.append($fileItem);
         });


### PR DESCRIPTION
Should use commiter date.

In the process of testing the typescript2 PR #65 I noticed a bug.
If for example a commit is rebased the commiter date and author date are not the same.

When I was rebasing my PR I found I was getting an exception when viewing commit details as the git log command was using the --before switch with the author date.
Therefore my commit (having an older author date than commit date) was not included in the results.
The code rightly assumes the commit of the file clicked on should be in the results which it wont be in the case of author date < commit date.

Could you merge this ASAP and I will rebase typescript2 #65 on these changes.

BTW I had to fix a couple of package versions to compile.
