### PR TITLE
When current folder is not a GIT root folder, need to detect correct …

### DIFF
--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -28,21 +28,23 @@ vscode.workspace.onDidCloseTextDocument(textDocument => {
 
 vscode.commands.registerCommand('git.viewFileCommitDetails', (sha1: string, relativeFilePath: string, isoStrictDateTime: string) => {
     const fileName = path.join(vscode.workspace.rootPath, relativeFilePath);
-    const gitRepositoryPath = vscode.workspace.rootPath;
-    historyUtil.getFileHistoryBefore(gitRepositoryPath, relativeFilePath, sha1, isoStrictDateTime).then((data: any[]) => {
-        const historyItem: any = data.find(data => data.sha1 === sha1);
-        const previousItems = data.filter(data => data.sha1 !== sha1);
-        historyItem.previousSha1 = previousItems.length === 0 ? '' : previousItems[0].sha1 as string;
-        const item: vscode.QuickPickItem = <vscode.QuickPickItem>{
-            label: '',
-            description: '',
-            data: historyItem,
-            isLast: historyItem.previousSha1.length === 0
-        };
-        onItemSelected(item, fileName, relativeFilePath);
-    }, ex => {
-        vscode.window.showErrorMessage(`There was an error in retrieving the file history. (${ex.message ? ex.message : ex + ''})`);
-    });
+    historyUtil.getGitRepositoryPath(vscode.workspace.rootPath).then(
+        (gitRepositoryPath) => {
+            historyUtil.getFileHistoryBefore(gitRepositoryPath, relativeFilePath, sha1, isoStrictDateTime).then((data: any[]) => {
+                const historyItem: any = data.find(data => data.sha1 === sha1);
+                const previousItems = data.filter(data => data.sha1 !== sha1);
+                historyItem.previousSha1 = previousItems.length === 0 ? '' : previousItems[0].sha1 as string;
+                const item: vscode.QuickPickItem = <vscode.QuickPickItem>{
+                    label: '',
+                    description: '',
+                    data: historyItem,
+                    isLast: historyItem.previousSha1.length === 0
+                };
+                onItemSelected(item, fileName, relativeFilePath);
+            }, ex => {
+                vscode.window.showErrorMessage(`There was an error in retrieving the file history. (${ex.message ? ex.message : ex + ''})`);
+            });
+   }).then(() => { }, error => genericErrorHandler(error));
 });
 
 export function run(fileName: string): any {

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -85,7 +85,8 @@ export function getGitRepositoryPath(fileName: string): Thenable<string> {
 
     return getGitPath().then((gitExecutable) =>
         new Promise<string>((resolve, reject) => {
-            let options = { cwd: path.dirname(fileName) };
+            let directory = fs.statSync(fileName).isDirectory() ? fileName : path.dirname(fileName);
+            let options = { cwd: directory };
 
             // git rev-parse --git-dir
             let ls = spawn(gitExecutable, ['rev-parse', '--show-toplevel'], options);


### PR DESCRIPTION
…root. Otherwise detailed view can't show details.

This is the second try (see https://github.com/DonJayamanne/gitHistoryVSCode/pull/75 reviewed by @mikes-gh )

Now the `getGitRepositoryPath` checks if passed parameter is a directory, so that both cases work

1.  Directory in the root of git repo is opened
2. Directory other than root of git repo is opened

