### PR TITLE
General fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
         "lint": "tslint ./src/**/*.ts || tslint ./test/**/*.ts"
     },
     "devDependencies": {
-        "typescript": "^2.0.10",
-        "tslint": "^4.0.2",
+        "typescript": "^2.1.4",
+        "tslint": "^4.1.1",
         "vscode": "^1.0.3",
         "mocha": "^2.3.3",
         "@types/node": "^6.0.49",

--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -31,7 +31,7 @@ vscode.commands.registerCommand('git.viewFileCommitDetails', (sha1: string, rela
     relativeFilePath = htmlDecode(relativeFilePath);
     const fileName = path.join(vscode.workspace.rootPath, relativeFilePath);
     historyUtil.getGitRepositoryPath(vscode.workspace.rootPath).then((gitRepositoryPath) => {
-        historyUtil.getFileHistoryBefore(gitRepositoryPath, relativeFilePath, sha1, isoStrictDateTime).then((data: any[]) => {
+        historyUtil.getFileHistoryBefore(gitRepositoryPath, relativeFilePath, isoStrictDateTime).then((data: any[]) => {
             const historyItem: any = data.find(data => data.sha1 === sha1);
             const previousItems = data.filter(data => data.sha1 !== sha1);
             historyItem.previousSha1 = previousItems.length === 0 ? '' : previousItems[0].sha1 as string;

--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as historyUtil from '../helpers/historyUtils';
 import * as path from 'path';
 import * as tmp from 'tmp';
+import { decode as htmlDecode }  from 'he';
 
 // TODO:Clean up this mess
 
@@ -27,6 +28,7 @@ vscode.workspace.onDidCloseTextDocument(textDocument => {
 });
 
 vscode.commands.registerCommand('git.viewFileCommitDetails', (sha1: string, relativeFilePath: string, isoStrictDateTime: string) => {
+    relativeFilePath = htmlDecode(relativeFilePath);
     const fileName = path.join(vscode.workspace.rootPath, relativeFilePath);
     const gitRepositoryPath = vscode.workspace.rootPath;
     historyUtil.getFileHistoryBefore(gitRepositoryPath, relativeFilePath, sha1, isoStrictDateTime).then((data: any[]) => {

--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -30,21 +30,22 @@ vscode.workspace.onDidCloseTextDocument(textDocument => {
 vscode.commands.registerCommand('git.viewFileCommitDetails', (sha1: string, relativeFilePath: string, isoStrictDateTime: string) => {
     relativeFilePath = htmlDecode(relativeFilePath);
     const fileName = path.join(vscode.workspace.rootPath, relativeFilePath);
-    const gitRepositoryPath = vscode.workspace.rootPath;
-    historyUtil.getFileHistoryBefore(gitRepositoryPath, relativeFilePath, sha1, isoStrictDateTime).then((data: any[]) => {
-        const historyItem: any = data.find(data => data.sha1 === sha1);
-        const previousItems = data.filter(data => data.sha1 !== sha1);
-        historyItem.previousSha1 = previousItems.length === 0 ? '' : previousItems[0].sha1 as string;
-        const item: vscode.QuickPickItem = <vscode.QuickPickItem>{
-            label: '',
-            description: '',
-            data: historyItem,
-            isLast: historyItem.previousSha1.length === 0
-        };
-        onItemSelected(item, fileName, relativeFilePath);
-    }, ex => {
-        vscode.window.showErrorMessage(`There was an error in retrieving the file history. (${ex.message ? ex.message : ex + ''})`);
-    });
+    historyUtil.getGitRepositoryPath(vscode.workspace.rootPath).then((gitRepositoryPath) => {
+        historyUtil.getFileHistoryBefore(gitRepositoryPath, relativeFilePath, sha1, isoStrictDateTime).then((data: any[]) => {
+            const historyItem: any = data.find(data => data.sha1 === sha1);
+            const previousItems = data.filter(data => data.sha1 !== sha1);
+            historyItem.previousSha1 = previousItems.length === 0 ? '' : previousItems[0].sha1 as string;
+            const item: vscode.QuickPickItem = <vscode.QuickPickItem>{
+                label: '',
+                description: '',
+                data: historyItem,
+                isLast: historyItem.previousSha1.length === 0
+            };
+            onItemSelected(item, fileName, relativeFilePath);
+        }, ex => {
+            vscode.window.showErrorMessage(`There was an error in retrieving the file history. (${ex.message ? ex.message : ex + ''})`);
+        });
+    }).then(() => { }, error => genericErrorHandler(error));
 });
 
 export function run(fileName: string): any {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as viewer from './logViewer/main';
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-    const outChannel = vscode.window.createOutputChannel('Git');
+    const outChannel = vscode.window.createOutputChannel('Git History');
     history.activate(outChannel);
     let disposable = vscode.commands.registerCommand('git.viewFileHistory', (fileUri?: vscode.Uri) => {
         outChannel.clear();

--- a/src/helpers/gitHistory.ts
+++ b/src/helpers/gitHistory.ts
@@ -68,6 +68,12 @@ export function getHistory(rootDir: string, pageIndex: number = 0, pageSize: num
                 error += data;
             });
 
+            ls.on('error', function(error) {
+                console.error(error);
+                reject(error);
+                return;
+            });
+
             ls.on('close', () => {
                 if (error.length > 0) {
                     reject(error);

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -8,13 +8,18 @@ export function getGitPath(): Promise<string> {
     return new Promise((resolve, reject) => {
         let gitPath = <string>vscode.workspace.getConfiguration('git').get('path');
         if (typeof gitPath === 'string' && gitPath.length > 0) {
-            resolve(gitPath);
+            if (fs.existsSync(gitPath)) {
+                resolve(gitPath);
+                return;
+            }
         }
 
         if (process.platform !== 'win32') {
             // Default: search in PATH environment variable
             resolve('git');
-        } else {
+            return;
+        }
+        else {
             // in Git for Windows, the recommendation is not to put git into the PATH.
             // Instead, there is an entry in the Registry.
 

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -106,6 +106,12 @@ export function getGitRepositoryPath(fileName: string): Thenable<string> {
                 error += data;
             });
 
+            ls.on('error', function(error) {
+                console.error(error);
+                reject(error);
+                return;
+            });
+
             ls.on('close', function() {
                  if (error.length > 0) {
                     reject(error);
@@ -150,6 +156,12 @@ function getLog(rootDir: string, args: string[]): Thenable<any[]> {
                 error += data;
             });
 
+            ls.on('error', function(error) {
+                console.error(error);
+                reject(error);
+                return;
+            });
+
             ls.on('close', function() {
                 if (error.length > 0) {
                     reject(error);
@@ -175,6 +187,12 @@ export function writeFile(rootDir: string, commitSha1: string, sourceFilePath: s
 
             ls.stderr.on('data', function (data) {
                 error += data;
+            });
+
+            ls.on('error', function(error) {
+                console.error(error);
+                reject(error);
+                return;
             });
 
             ls.on('close', function() {

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -85,7 +85,8 @@ export function getGitRepositoryPath(fileName: string): Thenable<string> {
 
     return getGitPath().then((gitExecutable) =>
         new Promise<string>((resolve, reject) => {
-            let options = { cwd: path.dirname(fileName) };
+            let directory = fs.statSync(fileName).isDirectory() ? fileName : path.dirname(fileName);
+            let options = { cwd: directory };
 
             // git rev-parse --git-dir
             let ls = spawn(gitExecutable, ['rev-parse', '--show-toplevel'], options);

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -115,10 +115,10 @@ export function getGitRepositoryPath(fileName: string): Thenable<string> {
 }
 
 export function getFileHistory(rootDir: string, relativeFilePath: string): Thenable<any[]> {
-    return getLog(rootDir, relativeFilePath, ['--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--parents', '--numstat', '--topo-order', '--raw', '--follow', relativeFilePath]);
+    return getLog(rootDir, relativeFilePath, ['--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--parents', '--numstat', '--topo-order', '--raw', '--follow', '--', relativeFilePath]);
 }
 export function getFileHistoryBefore(rootDir: string, relativeFilePath: string, sha1: string, isoStrictDateTime: string): Thenable<any[]> {
-    return getLog(rootDir, relativeFilePath, [`--max-count=10`, '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', `--before='${isoStrictDateTime}'`, relativeFilePath]);
+    return getLog(rootDir, relativeFilePath, [`--max-count=10`, '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', `--before='${isoStrictDateTime}'`, '--', relativeFilePath]);
 }
 
 export function getLineHistory(rootDir: string, relativeFilePath: string, lineNumber: number): Thenable<any[]> {
@@ -131,7 +131,8 @@ function getLog(rootDir: string, relativeFilePath: string, args: string[]): Then
     return getGitPath().then((gitExecutable) =>
         new Promise<any[]>((resolve, reject) => {
             let options = { cwd: rootDir };
-            let ls = spawn(gitExecutable, ['log', ...args], options);
+            args.unshift('log');
+            let ls = spawn(gitExecutable, args, options);
 
             let log = '';
             let error = '';

--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -116,18 +116,18 @@ export function getGitRepositoryPath(fileName: string): Thenable<string> {
 }
 
 export function getFileHistory(rootDir: string, relativeFilePath: string): Thenable<any[]> {
-    return getLog(rootDir, relativeFilePath, ['--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--parents', '--numstat', '--topo-order', '--raw', '--follow', '--', relativeFilePath]);
+    return getLog(rootDir, ['--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--parents', '--numstat', '--topo-order', '--raw', '--follow', '--', relativeFilePath]);
 }
-export function getFileHistoryBefore(rootDir: string, relativeFilePath: string, sha1: string, isoStrictDateTime: string): Thenable<any[]> {
-    return getLog(rootDir, relativeFilePath, [`--max-count=10`, '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', `--before='${isoStrictDateTime}'`, '--', relativeFilePath]);
+export function getFileHistoryBefore(rootDir: string, relativeFilePath: string, isoStrictDateTime: string): Thenable<any[]> {
+    return getLog(rootDir, [`--max-count=10`, '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', `--before='${isoStrictDateTime}'`, '--', relativeFilePath]);
 }
 
 export function getLineHistory(rootDir: string, relativeFilePath: string, lineNumber: number): Thenable<any[]> {
     let lineArgs = '-L' + lineNumber + ',' + lineNumber + ':' + relativeFilePath.replace(/\\/g, '/');
-    return getLog(rootDir, relativeFilePath, [lineArgs, '--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--numstat', '--topo-order', '--raw']);
+    return getLog(rootDir, [lineArgs, '--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--numstat', '--topo-order', '--raw']);
 }
 
-function getLog(rootDir: string, relativeFilePath: string, args: string[]): Thenable<any[]> {
+function getLog(rootDir: string, args: string[]): Thenable<any[]> {
 
     return getGitPath().then((gitExecutable) =>
         new Promise<any[]>((resolve, reject) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "outDir": "out",
         "rootDir": ".",
         "sourceMap": true,
-        "target": "es5",
+        "target": "es6",
 
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,


### PR DESCRIPTION
- Fix #53 HTML chars in filenames
- Fix #77 git log above repo root (Credit to [malytskyy](https://github.com/malytskyy))
- Fix #83 Rename outChannel to 'Git History'
- Fix #78 and Fix #46 Don't use incorrectly configured git.path
- Fix #46 Add error handling for spawned processes (Credit to [SE2Dev](https://github.com/SE2Dev))
- Fix #88 tmp file cleanup.  There is a lot of effort to manually cleanup when tmp does it all anyway.
onDidCloseTextDocument fires whenever the document is not visible so it not the place to do stuff when the document is actually closed.

- Remove unused parameters.
- Update typescript to 2.1 and update to ES6 target (allowing async await in place of .then)
