### PR TITLE
Add gitmoji support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "resources/gemoji"]
+	path = resources/gemoji
+	url = https://github.com/github/gemoji.git

--- a/src/browser/detailsView.ts
+++ b/src/browser/detailsView.ts
@@ -1,4 +1,5 @@
 import * as contracts from '../contracts';
+import { gitmojify } from '../helpers/gitmojify';
 
 (function () {
     let logEntries: contracts.LogEntry[];
@@ -65,7 +66,7 @@ import * as contracts from '../contracts';
             $detailsView.removeClass('hidden');
         }
 
-        $('.commit-subject', $detailsView).html(entry.subject);
+        $('.commit-subject', $detailsView).html(gitmojify(entry.subject));
         $('.commit-author .name', $detailsView)
           .attr('aria-label', entry.author.email)
           .html(entry.author.name);
@@ -74,8 +75,9 @@ import * as contracts from '../contracts';
           .html(' on ' + entry.author.localisedDate);
 
         $('.commit-body', $detailsView)
-          .html(entry.body);
-        $('.commit-notes', $detailsView).html(entry.notes);
+          .html(gitmojify(entry.body));
+        $('.commit-notes', $detailsView)
+          .html(gitmojify(entry.notes));
         let $files = $('.committed-files', $detailsView);
         $files.html('');
         entry.fileStats.forEach(stat => {

--- a/src/helpers/gitmojify.ts
+++ b/src/helpers/gitmojify.ts
@@ -1,0 +1,23 @@
+const emojis = require('../../../resources/gemoji/db/emoji.json');
+
+/**
+ * A gitmoji.
+ */
+interface Gitmoji {
+    /** The long emoji code with colons. */
+    code: string,
+
+    /** The actual emoji. */
+    emoji: string
+}
+
+const gitmojis: Gitmoji[] = [];
+emojis.forEach((e: any) => e.aliases.forEach((alias: string) => gitmojis.push({
+    code: ':' + alias + ':',
+    emoji: e.emoji
+})));
+
+export function gitmojify(message: string): string {
+    gitmojis.forEach((gitmoji: Gitmoji) => message = message.replace(gitmoji.code, gitmoji.emoji));
+    return message;
+}

--- a/src/logViewer/htmlGenerator.ts
+++ b/src/logViewer/htmlGenerator.ts
@@ -1,5 +1,6 @@
 import { LogEntry } from '../contracts';
 import { encode as htmlEncode } from 'he';
+import { gitmojify } from '../helpers/gitmojify';
 
 export function generateErrorView(error: any): string {
     return `
@@ -92,6 +93,7 @@ function generateHistoryListContainer(entries: LogEntry[], entriesHtml: string, 
 
 export function generateHistoryHtmlView(entries: LogEntry[], canGoPrevious: boolean, canGoNext: boolean): string {
     const entriesHtml = entries.map((entry, entryIndex) => {
+        const subject = gitmojify(entry.subject);
         return `
             <div class="log-entry">
                 <div class="media right">
@@ -100,8 +102,7 @@ export function generateHistoryHtmlView(entries: LogEntry[], canGoPrevious: bool
                             <div class="copy-button">
                                 <span class="btn clipboard hint--bottom hint--rounded hint--bounce"
                                     data-clipboard-text="${entry.sha1.full}"
-                                    aria-label="Copy the full SHA"
-                                >
+                                    aria-label="Copy the full SHA">
                                     <i class="octicon octicon-clippy"></i>
                                     <a class="clipboard-link" href="${encodeURI('command:git.copyText?' + JSON.stringify([entry.sha1.full]))}"></a>
                                 </span>
@@ -112,8 +113,8 @@ export function generateHistoryHtmlView(entries: LogEntry[], canGoPrevious: bool
                         </div>
                     </div>
                     <div class="media-content">
-                        <a class="commit-subject-link">${htmlEncode(entry.subject)}</a>
-                        <div class="commit-subject" data-entry-index="${entryIndex}">${htmlEncode(entry.subject)}</div>
+                        <a class="commit-subject-link">${htmlEncode(subject)}</a>
+                        <div class="commit-subject" data-entry-index="${entryIndex}">${htmlEncode(subject)}</div>
                         <div class="commit-author">
                             <span class="name hint--right hint--rounded hint--bounce" aria-label="${entry.author.email}">${htmlEncode(entry.author.name)}</span>
                             <span class="timestamp">on ${entry.author.localisedDate}</span>


### PR DESCRIPTION
This PR adds gitmoji support to git history for VS Code.

Gitmoji is an attempt at standardizing Emoji usage in git commit messages. It makes a practical and fun way to categorize what you've done in your commits. 😄 Github also supports displaying Gitmoji in commit messages, so everything looks fine, even in the browser. Please see https://github.com/carloscuesta/gitmoji for more details.

The way I've chosen to implement gitmoji is by adding a git submodule to the [Github/gemoji](https://github.com/github/gemoji) repository that contains all emojis. This makes it simple to track changes to the emoji repo and we're not including data in the repository. The downside of this is that the repo contains some (but not much) ruby code.

This is what the log view looks like without gitmoji support:
![No Gitmoji Support](https://cloud.githubusercontent.com/assets/1683034/21652222/27309114-d2ac-11e6-9832-57264de08716.png)

And this is what it looks like with Gitmoji support:
![Gitmoji Support](https://cloud.githubusercontent.com/assets/1683034/21651553/5161f660-d2a9-11e6-8e5f-74fbc0fd951f.png)
Much better to me!
