### PR TITLE
Allow scenario where git repo root is not the vscode workspace root.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
                 {
                     "command": "git.viewFileHistory",
                     "group": "git"
+                },
+                {
+                    "command": "git.viewHistory",
+                    "group": "git"
                 }
             ]
         },


### PR DESCRIPTION
Fixes #103 

vscode itself expects the repo root to be workspace root for all its git functions to work.
There is a [vscode issue](https://github.com/Microsoft/vscode/issues/396) to support git repos above the root but likely that will not be happening very soon.

This PR allows all the git history commands to work in repos that are not at the vscode workspace root.

For git log we need some context.
For this reason we have added a right click to vIew the log.
If there is no context (such as when typing the command in the command bar) we look at the current editor window and use that file as the repo locator.  If that fails we assume the workspace root is the repo root as before.