### PR TITLE
Support matchOnDetail while viewing fileHistory

### DIFF
--- a/src/commands/fileHistory.ts
+++ b/src/commands/fileHistory.ts
@@ -85,7 +85,7 @@ export async function run(fileName: string) {
             }
         });
 
-        vscode.window.showQuickPick(itemPickList, { placeHolder: '', matchOnDescription: true }).then(item => {
+        vscode.window.showQuickPick(itemPickList, { placeHolder: '', matchOnDescription: true , matchOnDetail: true }).then(item => {
             if (!item) {
                 return;
             }


### PR DESCRIPTION
I was thinking it would be better to have `matchOnDetail` feature, see below:

![screen shot 2017-04-27 at 5 23 56 pm](https://cloud.githubusercontent.com/assets/1059956/25477079/d3cd8fc4-2b6e-11e7-97e3-2847478cae96.png)


Sometimes, i just want to filter by the author, but author information is placed at `detail`.
