### PR TITLE
fix error when git config log.abbrevcommit=true

### DIFF
--- a/src/helpers/historyUtils.ts
+++ b/src/helpers/historyUtils.ts
@@ -5,10 +5,10 @@ import * as gitPaths from './gitPaths';
 import * as logger from '../logger';
 
 export async function getFileHistory(rootDir: string, relativeFilePath: string): Promise<any[]> {
-    return await getLog(rootDir, ['--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--parents', '--numstat', '--topo-order', '--raw', '--follow', '--', relativeFilePath]);
+    return await getLog(rootDir, ['--no-abbrev-commit', '--max-count=50', '--decorate=full', '--date=default', '--pretty=fuller', '--parents', '--numstat', '--topo-order', '--raw', '--follow', '--', relativeFilePath]);
 }
 export async function getFileHistoryBefore(rootDir: string, relativeFilePath: string, isoStrictDateTime: string): Promise<any[]> {
-    return await getLog(rootDir, [`--max-count=10`, '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', `--before='${isoStrictDateTime}'`, '--', relativeFilePath]);
+    return await getLog(rootDir, ['--no-abbrev-commit', `--max-count=10`, '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw', '--follow', `--before='${isoStrictDateTime}'`, '--', relativeFilePath]);
 }
 
 export async function getLineHistory(rootDir: string, relativeFilePath: string, lineNumber: number): Promise<any[]> {


### PR DESCRIPTION
If the git config setting log.abbrevcommit is set to true then when you click on a file in the history view to see the details you get an error. The source of the error is from the git.viewFileCommitDetails callback and is `TypeError: Cannot set property 'previousSha1' of undefined`.

It appears that the full SHA1 is being passed into the function but is trying to compare it to an abbreviated SHA1 from a call to git log. I solved this by adding the --no-abbrev-commit argument to the call to git log which overrides the log.abbrevcommit setting.