### PR TITLE
View log by branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "githistory",
     "displayName": "Git History (git log)",
     "description": "View git log, file or line History",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "donjayamanne",
     "author": {
         "name": "Don Jayamanne",

--- a/src/helpers/gitPaths.ts
+++ b/src/helpers/gitPaths.ts
@@ -144,7 +144,7 @@ export async function getGitRepositoryPath(fileName: string): Promise<string> {
     });
 }
 
-export async function getGitBranch(repoPath: string) : Promise<string> {
+export async function getGitBranch(repoPath: string): Promise<string> {
     const gitPath = await getGitPath();
     return new Promise<string>((resolve, reject) => {
         const options = { cwd: repoPath };
@@ -153,7 +153,7 @@ export async function getGitBranch(repoPath: string) : Promise<string> {
         let error = '';
         let ls = spawn(gitPath, args, options);
         ls.stdout.on('data', function (data) {
-            branch += data.slice(0,-1);
+            branch += data.slice(0, -1);
         });
 
         ls.stderr.on('data', function (data) {

--- a/src/helpers/gitPaths.ts
+++ b/src/helpers/gitPaths.ts
@@ -143,3 +143,31 @@ export async function getGitRepositoryPath(fileName: string): Promise<string> {
         });
     });
 }
+
+export async function getGitBranch(repoPath: string) : Promise<string> {
+    const gitPath = await getGitPath();
+    return new Promise<string>((resolve, reject) => {
+        const options = { cwd: repoPath };
+        const args = ['rev-parse', '--abbrev-ref', 'HEAD'];
+        let branch = '';
+        let error = '';
+        let ls = spawn(gitPath, args, options);
+        ls.stdout.on('data', function (data) {
+            branch += data.slice(0,-1);
+        });
+
+        ls.stderr.on('data', function (data) {
+            error += data;
+        });
+
+        ls.on('error', function (error) {
+            logger.logError(error);
+            reject(error);
+            return;
+        });
+
+        ls.on('close', function () {
+            resolve(branch);
+        });
+    });
+}

--- a/src/helpers/logParser.ts
+++ b/src/helpers/logParser.ts
@@ -179,7 +179,7 @@ export function parseLogEntry(lines: string[]): LogEntry | null {
 
     lines.forEach((line, index, lines) => {
         if (line.indexOf(prefixes.refs) === 0) {
-            regMatch = line.match(/HEAD -> refs\/heads\/([\w_\-.]+)/);
+            regMatch = line.match(/HEAD -> refs\/heads\/([\w_\-\/.]+)/);
 
             if (regMatch !== null) {
                 logEntry.headRef = regMatch[1];


### PR DESCRIPTION
This PR allows the user to display the git history per branch using the command "git.viewHistory".
It also caches the results (to load faster when switching between tabs) and fixes an issues when local branches contain a slash

![log-by-branch](https://user-images.githubusercontent.com/4850116/28271527-1059a23c-6b09-11e7-96da-fc9a8fe4f1b9.gif)
