### PR TITLE
Feature: Provide an option to view history log for all branches

### DIFF
--- a/src/helpers/gitHistory.ts
+++ b/src/helpers/gitHistory.ts
@@ -9,10 +9,16 @@ const LOG_ENTRY_SEPARATOR = '95E9659B-27DC-43C4-A717-D75969757EA5';
 const STATS_SEPARATOR = parser.STATS_SEPARATOR;
 const LOG_FORMAT = `--format="%n${LOG_ENTRY_SEPARATOR}%nrefs=%d%ncommit=%H%ncommitAbbrev=%h%ntree=%T%ntreeAbbrev=%t%nparents=%P%nparentsAbbrev=%p%nauthor=%an <%ae> %at%ncommitter=%cn <%ce> %ct%nsubject=%s%nbody=%b%n%nnotes=%N%n${STATS_SEPARATOR}%n"`;
 
-export async function getLogEntries(rootDir: string, pageIndex: number = 0, pageSize: number = 100): Promise<LogEntry[]> {
-    const args = ['log', LOG_FORMAT, '--date-order', '--decorate=full', `--skip=${pageIndex * pageSize}`, `--max-count=${pageSize}`, '--numstat', '--'];
-    // This is how you can view the log across all branches
-    // args = ['log', LOG_FORMAT, '--date-order', '--decorate=full', `--skip=${pageIndex * pageSize}`, `--max-count=${pageSize}`, '--all', '--']
+export async function getLogEntries(rootDir: string, branchName: string, pageIndex: number = 0, pageSize: number = 100): Promise<LogEntry[]> {
+
+    let args: string[];
+    if (branchName && branchName.length > 0) {
+        args = ['log', LOG_FORMAT, '--date-order', '--decorate=full', `--skip=${pageIndex * pageSize}`, `--max-count=${pageSize}`, '--numstat', '--'];
+    }
+    else {
+        args = ['log', LOG_FORMAT, '--date-order', '--decorate=full', `--skip=${pageIndex * pageSize}`, `--max-count=${pageSize}`, '--all', '--numstat', '--'];
+    }
+
     const gitPath = await getGitPath();
     return new Promise<LogEntry[]>((resolve, reject) => {
         const options = { cwd: rootDir };
@@ -71,7 +77,7 @@ export async function getLogEntries(rootDir: string, pageIndex: number = 0, page
             error += data;
         });
 
-        ls.on('error', function(error) {
+        ls.on('error', function (error) {
             logger.logError(error);
             reject(error);
             return;

--- a/src/helpers/logParser.ts
+++ b/src/helpers/logParser.ts
@@ -229,10 +229,6 @@ export function parseLogEntry(lines: string[]): LogEntry | null {
             logEntry.committer = parseAuthCommitter(line.substring(prefixLengths.committer));
             return;
         }
-        if (line.indexOf(prefixes.committer) === 0) {
-            logEntry.committer = parseAuthCommitter(line.substring(prefixLengths.committer));
-            return;
-        }
         if (line.indexOf(prefixes.subject) === 0) {
             logEntry.subject = line.substring(prefixLengths.subject).trim();
             return;

--- a/src/logViewer/logViewer.ts
+++ b/src/logViewer/logViewer.ts
@@ -120,8 +120,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     let disposable = vscode.commands.registerCommand('git.viewHistory', async (fileUri?: vscode.Uri) => {
         const itemPickList: vscode.QuickPickItem[] = [];
-        itemPickList.push({ label: 'Current branch', description: 'Show history of only the current branch' });
-        itemPickList.push({ label: 'All branches', description: 'Show history of all the branches' });
+        itemPickList.push({ label: 'Current branch', description: '' });
+        itemPickList.push({ label: 'All branches', description: '' });
         let modeChoice = await vscode.window.showQuickPick(itemPickList, { placeHolder: 'Show history for...', matchOnDescription: true });
 
         let title: string;

--- a/src/logViewer/logViewer.ts
+++ b/src/logViewer/logViewer.ts
@@ -128,34 +128,36 @@ export function activate(context: vscode.ExtensionContext) {
         if (modeChoice === undefined) {
             return;
         }
-        else if (modeChoice.label === 'All branches') {
+
+        let fileName = '';
+        let branchName = 'master';
+
+        if (fileUri && fileUri.fsPath) {
+            fileName = fileUri.fsPath;
+        }
+        else {
+            if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
+                fileName = vscode.window.activeTextEditor.document.fileName;
+            }
+        }
+        if (fileName !== '') {
+            gitRepoPath = await gitPaths.getGitRepositoryPath(fileName);
+        }
+        else {
+            gitRepoPath = vscode.workspace.rootPath;
+        }
+
+        branchName = await gitPaths.getGitBranch(gitRepoPath);
+
+        pageIndex = 0;
+        canGoPrevious = false;
+        canGoNext = true;
+
+        if (modeChoice.label === 'All branches') {
             previewUri = vscode.Uri.parse(gitHistorySchema + '://authority/git-history');
             title = 'Git History (all branches)';
         }
         else {
-            let fileName = '';
-            let branchName = 'master';
-
-            if (fileUri && fileUri.fsPath) {
-                fileName = fileUri.fsPath;
-            }
-            else {
-                if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
-                    fileName = vscode.window.activeTextEditor.document.fileName;
-                }
-            }
-            if (fileName !== '') {
-                gitRepoPath = await gitPaths.getGitRepositoryPath(fileName);
-            }
-            else {
-                gitRepoPath = vscode.workspace.rootPath;
-            }
-
-            branchName = await gitPaths.getGitBranch(gitRepoPath);
-
-            pageIndex = 0;
-            canGoPrevious = false;
-            canGoNext = true;
             previewUri = vscode.Uri.parse(gitHistorySchema + '://authority/git-history?branch=' + encodeURI(branchName));
             title = 'Git History (' + branchName + ')';
         }

--- a/src/logViewer/logViewer.ts
+++ b/src/logViewer/logViewer.ts
@@ -27,10 +27,10 @@ class TextDocumentContentProvider implements vscode.TextDocumentContentProvider 
     public async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
         try {
             let branchName = this.getBranchFromURI(uri);
-            if ( this.html.hasOwnProperty(branchName) ) {
+            if (this.html.hasOwnProperty(branchName)) {
                 return this.html[branchName];
             }
-            const entries = await gitHistory.getLogEntries(gitRepoPath, pageIndex, pageSize);
+            const entries = await gitHistory.getLogEntries(gitRepoPath, branchName, pageIndex, pageSize);
             canGoPrevious = pageIndex > 0;
             canGoNext = entries.length === pageSize;
             this.entries = entries;
@@ -53,14 +53,18 @@ class TextDocumentContentProvider implements vscode.TextDocumentContentProvider 
     }
 
     private clearCache(name: string) {
-        if ( this.html.hasOwnProperty(name) ) {
+        if (this.html.hasOwnProperty(name)) {
             delete this.html[name];
         }
     }
 
     private getBranchFromURI(uri: vscode.Uri): string {
-        let re = uri.query.match(/branch=([a-z0-9_\-.]+)/i);
-        return (re) ? re[1] : 'master';
+        if (uri.query.length > 0) {
+            let re = uri.query.match(/branch=([a-z0-9_\-.]+)/i);
+            return (re) ? re[1] : 'master';
+        } else {
+            return '';
+        }
     }
 
     private getStyleSheetPath(resourceName: string): string {
@@ -115,31 +119,47 @@ export function activate(context: vscode.ExtensionContext) {
     let registration = vscode.workspace.registerTextDocumentContentProvider(gitHistorySchema, provider);
 
     let disposable = vscode.commands.registerCommand('git.viewHistory', async (fileUri?: vscode.Uri) => {
-        let fileName = '';
-        let branchName = 'master';
+        const itemPickList: vscode.QuickPickItem[] = [];
+        itemPickList.push({ label: 'Current branch', description: 'Show history of only the current branch' });
+        itemPickList.push({ label: 'All branches', description: 'Show history of all the branches' });
+        let modeChoice = await vscode.window.showQuickPick(itemPickList, { placeHolder: 'Show history for...', matchOnDescription: true });
 
-        if (fileUri && fileUri.fsPath) {
-            fileName = fileUri.fsPath;
+        let title: string;
+        if (modeChoice === undefined) {
+            return;
+        }
+        else if (modeChoice.label === 'All branches') {
+            previewUri = vscode.Uri.parse(gitHistorySchema + '://authority/git-history');
+            title = 'Git History (all branches)';
         }
         else {
-            if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
-                fileName = vscode.window.activeTextEditor.document.fileName;
+            let fileName = '';
+            let branchName = 'master';
+
+            if (fileUri && fileUri.fsPath) {
+                fileName = fileUri.fsPath;
             }
-        }
-        if (fileName !== '') {
-            gitRepoPath = await gitPaths.getGitRepositoryPath(fileName);
-        }
-        else {
-            gitRepoPath = vscode.workspace.rootPath;
-        }
+            else {
+                if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
+                    fileName = vscode.window.activeTextEditor.document.fileName;
+                }
+            }
+            if (fileName !== '') {
+                gitRepoPath = await gitPaths.getGitRepositoryPath(fileName);
+            }
+            else {
+                gitRepoPath = vscode.workspace.rootPath;
+            }
 
-        branchName = await gitPaths.getGitBranch(gitRepoPath);
+            branchName = await gitPaths.getGitBranch(gitRepoPath);
 
-        pageIndex = 0;
-        canGoPrevious = false;
-        canGoNext = true;
-        previewUri = vscode.Uri.parse(gitHistorySchema + '://authority/git-history?branch=' + encodeURI(branchName) );
-        return vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.One, 'Git History (' + branchName + ')').then((success) => {
+            pageIndex = 0;
+            canGoPrevious = false;
+            canGoNext = true;
+            previewUri = vscode.Uri.parse(gitHistorySchema + '://authority/git-history?branch=' + encodeURI(branchName));
+            title = 'Git History (' + branchName + ')';
+        }
+        return vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.One, title).then((success) => {
             provider.update(previewUri);
         }, (reason) => {
             vscode.window.showErrorMessage(reason);


### PR DESCRIPTION
User is provided an option to select the mode of viewing the log history graph. The options are...

1. Current branch: This produces the current branch's log history graph (as is possible currently). This has been kept as the first option to allow the user to just press Enter quickly to get the default behavior.
1. All branches: This is the new mode in which you can see log history graph of all the branches.

The modified sequence of commands looks like the following...
![git log](https://user-images.githubusercontent.com/217481/28747520-6b542cf2-74be-11e7-95dc-b495ee24886d.png)

(new option selection GUI)...
![git log mode selection](https://user-images.githubusercontent.com/217481/28747418-b663fbf8-74bb-11e7-9bb7-93bc1af5f334.png)


Fixes #93 , fixes #129 