### PR TITLE
Add option to show or hide the Explorer panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
 		"views": {
 			"explorer": [{
 					"id": "commitViewProvider",
-					"name": "Commits"
+					"name": "Commits",
+					"when": "config.gitHistory.commit.showExplorer == true"
 				},
 				{
 					"id": "compareViewProvider",
-					"name": "Compare Commits"
+					"name": "Compare Commits",
+					"when": "config.gitHistory.compare.showExplorer == true"
 				}
 			]
 		},
@@ -178,6 +180,16 @@
 					"type": "string",
 					"default": "Debug",
 					"description": "Log Level [Debug|Info|Error]"
+				},
+				"gitHistory.commit.showExplorer": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show or hide the Commit Explorer"
+				},
+				"gitHistory.compare.showExplorer": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show or hide the Compare Explorer"
 				}
 			}
 		}


### PR DESCRIPTION
By default the explorer panel will be shown, however, if the user wants
to disable it, there is now an option via the two new configuration
options.

Fixes #150, #164