### PR TITLE
Restore "git log" alias for git.viewHistory

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
             },
             {
                 "command": "git.viewHistory",
-                "title": "Git: View History",
+                "title": "Git: View History (git log)",
                 "icon": {
                     "dark": "./resources/icons/dark/git.svg",
                     "light": "./resources/icons/light/git.svg"


### PR DESCRIPTION
Awesome plugin, definitely one of the most used.

Noticed that in v0.3.0 the `git log` alias disappeared for the `viewHistory` command (there was also a question about this https://github.com/DonJayamanne/gitHistoryVSCode/issues/182#issuecomment-358274886) - hoping we could reinstate it as it closely resembles the terminal `git log` command and seems logical to keep them the same.