### PR TITLE
Fix Command `git.viewFileHistory` appears multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,10 +77,6 @@
                 "title": "Git: Show Commit Comparison View Explorer"
             },
             {
-                "command": "git.viewFileHistory",
-                "title": "Git: View File History"
-            },
-            {
                 "command": "git.viewLineHistory",
                 "title": "Git: View Line History"
             },


### PR DESCRIPTION
In the WebKit Developer Tools Console there is a warning `/E:/Program Files/Microsoft VS Code/resources/app/out/vs/workbench/workbench.main.js:4183 [C:\Users\info_000\.vscode\extensions\donjayamanne.githistory-0.4.0]: Command `git.viewFileHistory` appears multiple times in the `commands` section`. Because command `git.viewFileHistory` in `project.json` duplicated. I fixed it