### PR TITLE
Add merge and rebase commands to history view

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,10 @@
                 "title": "Merge with this commit"
             },
             {
+                "command": "git.commit.rebase",
+                "title": "Rebase onto this commit"
+            },
+            {
                 "command": "git.commit.view.showFilesOnly",
                 "title": "Show files only"
             },
@@ -283,6 +287,11 @@
                 },
                 {
                     "command": "git.commit.merge",
+                    "when": "view == commitViewProvider && git.commit.selected",
+                    "group": "zMoreSubMenuItems"
+                },
+                {
+                    "command": "git.commit.rebase",
                     "when": "view == commitViewProvider && git.commit.selected",
                     "group": "zMoreSubMenuItems"
                 },

--- a/package.json
+++ b/package.json
@@ -153,6 +153,10 @@
                 "title": "Show folder view"
             },
             {
+                "command": "git.commit.merge",
+                "title": "Merge with this commit"
+            },
+            {
                 "command": "git.commit.view.showFilesOnly",
                 "title": "Show files only"
             },
@@ -274,6 +278,11 @@
                 },
                 {
                     "command": "git.commit.createBranch",
+                    "when": "view == commitViewProvider && git.commit.selected",
+                    "group": "zMoreSubMenuItems"
+                },
+                {
+                    "command": "git.commit.merge",
                     "when": "view == commitViewProvider && git.commit.selected",
                     "group": "zMoreSubMenuItems"
                 },

--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -362,6 +362,9 @@ export class Git implements IGitService {
     public async merge(hash: string): Promise<void> {
         await this.exec('merge', hash);
     }
+    public async rebase(hash: string): Promise<void> {
+        await this.exec('rebase', hash);
+    }
     private async exec(...args: string[]): Promise<string> {
         const gitRootPath = await this.getGitRoot();
         return this.gitCmdExecutor.exec(gitRootPath, ...args);

--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -7,7 +7,7 @@ import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../application/types/workspace';
 import { cache } from '../../common/cache';
 import { IServiceContainer } from '../../ioc/types';
-import { Branch, CommittedFile, FsUri, Hash, IGitService, LogEntries, LogEntry, ActionedUser } from '../../types';
+import { ActionedUser, Branch, CommittedFile, FsUri, Hash, IGitService, LogEntries, LogEntry } from '../../types';
 import { IGitCommandExecutor } from '../exec';
 import { IFileStatParser, ILogParser } from '../parsers/types';
 import { ITEM_ENTRY_SEPARATOR, LOG_ENTRY_SEPARATOR, LOG_FORMAT_ARGS } from './constants';
@@ -358,6 +358,9 @@ export class Git implements IGitService {
 
     public async createBranch(branchName: string, hash: string): Promise<void> {
         await this.exec('checkout', '-b', branchName, hash);
+    }
+    public async merge(hash: string): Promise<void> {
+        await this.exec('merge', hash);
     }
     private async exec(...args: string[]): Promise<string> {
         const gitRootPath = await this.getGitRoot();

--- a/src/commandFactories/commitFactory.ts
+++ b/src/commandFactories/commitFactory.ts
@@ -1,8 +1,9 @@
 import { inject, injectable } from 'inversify';
-import { IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCompareCommandHandler, IGitRevertCommandHandler } from '../commandHandlers/types';
+import { IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCompareCommandHandler, IGitMergeCommandHandler, IGitRevertCommandHandler } from '../commandHandlers/types';
 import { CherryPickCommand } from '../commands/commit/cherryPick';
 import { CompareCommand } from '../commands/commit/compare';
 import { CreateBranchCommand } from '../commands/commit/createBranch';
+import { MergeCommand } from '../commands/commit/merge';
 import { RevertCommand } from '../commands/commit/revert';
 import { SelectForComparison } from '../commands/commit/selectForComparion';
 import { ViewDetailsCommand } from '../commands/commit/viewDetails';
@@ -14,6 +15,7 @@ export class CommitCommandFactory implements ICommitCommandFactory {
     constructor( @inject(IGitBranchFromCommitCommandHandler) private branchCreationCommandHandler: IGitBranchFromCommitCommandHandler,
         @inject(IGitCherryPickCommandHandler) private cherryPickHandler: IGitCherryPickCommandHandler,
         @inject(IGitCompareCommandHandler) private compareHandler: IGitCompareCommandHandler,
+        @inject(IGitMergeCommandHandler) private mergeHandler: IGitMergeCommandHandler,
         @inject(IGitRevertCommandHandler) private revertHandler: IGitRevertCommandHandler,
         @inject(IGitCommitViewDetailsCommandHandler) private viewChangeLogHandler: IGitCommitViewDetailsCommandHandler) { }
     public async createCommands(commit: CommitDetails): Promise<ICommand<CommitDetails>[]> {
@@ -23,7 +25,8 @@ export class CommitCommandFactory implements ICommitCommandFactory {
             new ViewDetailsCommand(commit, this.viewChangeLogHandler),
             new SelectForComparison(commit, this.compareHandler),
             new RevertCommand(commit, this.revertHandler),
-            new CompareCommand(commit, this.compareHandler)
+            new CompareCommand(commit, this.compareHandler),
+            new MergeCommand(commit, this.mergeHandler)
         ];
 
         return (await Promise.all(commands.map(async cmd => {

--- a/src/commandFactories/commitFactory.ts
+++ b/src/commandFactories/commitFactory.ts
@@ -1,9 +1,10 @@
 import { inject, injectable } from 'inversify';
-import { IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCompareCommandHandler, IGitMergeCommandHandler, IGitRevertCommandHandler } from '../commandHandlers/types';
+import { IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCompareCommandHandler, IGitMergeCommandHandler, IGitRebaseCommandHandler, IGitRevertCommandHandler } from '../commandHandlers/types';
 import { CherryPickCommand } from '../commands/commit/cherryPick';
 import { CompareCommand } from '../commands/commit/compare';
 import { CreateBranchCommand } from '../commands/commit/createBranch';
 import { MergeCommand } from '../commands/commit/merge';
+import { RebaseCommand } from '../commands/commit/rebase';
 import { RevertCommand } from '../commands/commit/revert';
 import { SelectForComparison } from '../commands/commit/selectForComparion';
 import { ViewDetailsCommand } from '../commands/commit/viewDetails';
@@ -16,6 +17,7 @@ export class CommitCommandFactory implements ICommitCommandFactory {
         @inject(IGitCherryPickCommandHandler) private cherryPickHandler: IGitCherryPickCommandHandler,
         @inject(IGitCompareCommandHandler) private compareHandler: IGitCompareCommandHandler,
         @inject(IGitMergeCommandHandler) private mergeHandler: IGitMergeCommandHandler,
+        @inject(IGitRebaseCommandHandler) private rebaseHandler: IGitRebaseCommandHandler,
         @inject(IGitRevertCommandHandler) private revertHandler: IGitRevertCommandHandler,
         @inject(IGitCommitViewDetailsCommandHandler) private viewChangeLogHandler: IGitCommitViewDetailsCommandHandler) { }
     public async createCommands(commit: CommitDetails): Promise<ICommand<CommitDetails>[]> {
@@ -26,7 +28,8 @@ export class CommitCommandFactory implements ICommitCommandFactory {
             new SelectForComparison(commit, this.compareHandler),
             new RevertCommand(commit, this.revertHandler),
             new CompareCommand(commit, this.compareHandler),
-            new MergeCommand(commit, this.mergeHandler)
+            new MergeCommand(commit, this.mergeHandler),
+            new RebaseCommand(commit, this.rebaseHandler)
         ];
 
         return (await Promise.all(commands.map(async cmd => {

--- a/src/commandHandlers/commit/gitMerge.ts
+++ b/src/commandHandlers/commit/gitMerge.ts
@@ -1,0 +1,51 @@
+import { inject, injectable } from 'inversify';
+import { IApplicationShell } from '../../application/types';
+import { CommitDetails } from '../../common/types';
+import { IServiceContainer } from '../../ioc/types';
+import { IGitServiceFactory } from '../../types';
+import { ICommitViewerFactory } from '../../viewers/types';
+import { command } from '../registration';
+import { IGitMergeCommandHandler } from '../types';
+
+@injectable()
+export class GitMergeCommandHandler implements IGitMergeCommandHandler {
+    constructor( @inject(IServiceContainer) private serviceContainer: IServiceContainer,
+        @inject(ICommitViewerFactory) private commitViewerFactory: ICommitViewerFactory,
+        @inject(IApplicationShell) private applicationShell: IApplicationShell) { }
+
+    @command('git.commit.merge', IGitMergeCommandHandler)
+    public async merge(commit: CommitDetails, showPrompt: boolean = true) {
+        commit = commit ? commit : this.commitViewerFactory.getCommitViewer().selectedCommit;
+        const gitService = this.serviceContainer.get<IGitServiceFactory>(IGitServiceFactory).createGitService(commit.workspaceFolder);
+        const currentBranch = await gitService.getCurrentBranch();
+
+        const commitBranches = (await gitService.getRefsContainingCommit(commit.logEntry.hash.full))
+            .filter(value => value.length > 0);
+        const branchMsg = `Choose the commit/branch to merge into ${currentBranch}`;
+        const rev = await this.applicationShell.showQuickPick([commit.logEntry.hash.full, ...commitBranches], { placeHolder: branchMsg });
+
+        let type: string;
+        if (rev === undefined || rev.length === 0) {
+            return;
+        }
+        if (rev === commit.logEntry.hash.short) {
+            type = 'commit';
+        } else {
+            type = 'branch';
+        }
+
+        const msg = `Merge ${type} '${rev}' into ${currentBranch}?`;
+        const yesNo = showPrompt ? await this.applicationShell.showQuickPick(['Yes', 'No'], { placeHolder: msg }) : 'Yes';
+
+        if (yesNo === undefined || yesNo === 'No') {
+            return;
+        }
+
+        gitService.merge(rev)
+            .catch(err => {
+                if (typeof err === 'string') {
+                    this.applicationShell.showErrorMessage(err);
+                }
+            });
+    }
+}

--- a/src/commandHandlers/serviceRegistry.ts
+++ b/src/commandHandlers/serviceRegistry.ts
@@ -7,13 +7,14 @@ import { GitCherryPickCommandHandler } from './commit/gitCherryPick';
 import { GitCommitCommandHandler } from './commit/gitCommit';
 import { GitCommitViewDetailsCommandHandler } from './commit/gitCommitDetails';
 import { GitMergeCommandHandler } from './commit/gitMerge';
+import { GitRebaseCommandHandler } from './commit/gitRebase';
 import { GitRevertCommandHandler } from './commit/revert';
 import { FileCommandHandler } from './file/file';
 import { GitCompareFileCommitCommandHandler } from './fileCommit/fileCompare';
 import { GitFileHistoryCommandHandler } from './fileCommit/fileHistory';
 import { GitHistoryCommandHandler } from './gitHistory';
 import { CommandHandlerManager } from './handlerManager';
-import { ICommandHandler, ICommandHandlerManager, IFileCommandHandler, IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCommitViewExplorerCommandHandler, IGitCompareCommandHandler, IGitCompareCommitViewExplorerCommandHandler, IGitCompareFileCommandHandler, IGitFileHistoryCommandHandler, IGitHistoryCommandHandler, IGitMergeCommandHandler, IGitRevertCommandHandler } from './types';
+import { ICommandHandler, ICommandHandlerManager, IFileCommandHandler, IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCommitViewExplorerCommandHandler, IGitCompareCommandHandler, IGitCompareCommitViewExplorerCommandHandler, IGitCompareFileCommandHandler, IGitFileHistoryCommandHandler, IGitHistoryCommandHandler, IGitMergeCommandHandler, IGitRebaseCommandHandler, IGitRevertCommandHandler } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IGitFileHistoryCommandHandler>(IGitFileHistoryCommandHandler, GitFileHistoryCommandHandler);
@@ -28,12 +29,14 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IGitCompareCommitViewExplorerCommandHandler>(IGitCompareCommitViewExplorerCommandHandler, GitCompareCommitViewExplorerCommandHandler);
     serviceManager.addSingleton<IFileCommandHandler>(IFileCommandHandler, FileCommandHandler);
     serviceManager.addSingleton<IGitMergeCommandHandler>(IGitMergeCommandHandler, GitMergeCommandHandler);
+    serviceManager.addSingleton<IGitRebaseCommandHandler>(IGitRebaseCommandHandler, GitRebaseCommandHandler);
     serviceManager.addSingleton<IGitRevertCommandHandler>(IGitRevertCommandHandler, GitRevertCommandHandler);
 
     [IGitFileHistoryCommandHandler, IGitBranchFromCommitCommandHandler, IGitHistoryCommandHandler,
         IGitCommitCommandHandler, IGitCherryPickCommandHandler, IGitCompareFileCommandHandler,
         IGitCommitViewExplorerCommandHandler, IGitCompareCommitViewExplorerCommandHandler,
-        IFileCommandHandler, IGitMergeCommandHandler, IGitRevertCommandHandler].forEach(serviceIdentifier => {
+        IFileCommandHandler, IGitMergeCommandHandler, IGitRebaseCommandHandler,
+        IGitRevertCommandHandler].forEach(serviceIdentifier => {
             const instance = serviceManager.get<ICommandHandler>(serviceIdentifier);
             serviceManager.addSingletonInstance<ICommandHandler>(ICommandHandler, instance);
         });

--- a/src/commandHandlers/serviceRegistry.ts
+++ b/src/commandHandlers/serviceRegistry.ts
@@ -6,13 +6,14 @@ import { GitBranchFromCommitCommandHandler } from './commit/gitBranchFromCommit'
 import { GitCherryPickCommandHandler } from './commit/gitCherryPick';
 import { GitCommitCommandHandler } from './commit/gitCommit';
 import { GitCommitViewDetailsCommandHandler } from './commit/gitCommitDetails';
+import { GitMergeCommandHandler } from './commit/gitMerge';
 import { GitRevertCommandHandler } from './commit/revert';
 import { FileCommandHandler } from './file/file';
 import { GitCompareFileCommitCommandHandler } from './fileCommit/fileCompare';
 import { GitFileHistoryCommandHandler } from './fileCommit/fileHistory';
 import { GitHistoryCommandHandler } from './gitHistory';
 import { CommandHandlerManager } from './handlerManager';
-import { ICommandHandler, ICommandHandlerManager, IFileCommandHandler, IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCommitViewExplorerCommandHandler, IGitCompareCommandHandler, IGitCompareCommitViewExplorerCommandHandler, IGitCompareFileCommandHandler, IGitFileHistoryCommandHandler, IGitHistoryCommandHandler, IGitRevertCommandHandler } from './types';
+import { ICommandHandler, ICommandHandlerManager, IFileCommandHandler, IGitBranchFromCommitCommandHandler, IGitCherryPickCommandHandler, IGitCommitCommandHandler, IGitCommitViewDetailsCommandHandler, IGitCommitViewExplorerCommandHandler, IGitCompareCommandHandler, IGitCompareCommitViewExplorerCommandHandler, IGitCompareFileCommandHandler, IGitFileHistoryCommandHandler, IGitHistoryCommandHandler, IGitMergeCommandHandler, IGitRevertCommandHandler } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IGitFileHistoryCommandHandler>(IGitFileHistoryCommandHandler, GitFileHistoryCommandHandler);
@@ -26,12 +27,13 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IGitCompareCommandHandler>(IGitCompareCommandHandler, GitCompareCommitCommandHandler);
     serviceManager.addSingleton<IGitCompareCommitViewExplorerCommandHandler>(IGitCompareCommitViewExplorerCommandHandler, GitCompareCommitViewExplorerCommandHandler);
     serviceManager.addSingleton<IFileCommandHandler>(IFileCommandHandler, FileCommandHandler);
+    serviceManager.addSingleton<IGitMergeCommandHandler>(IGitMergeCommandHandler, GitMergeCommandHandler);
     serviceManager.addSingleton<IGitRevertCommandHandler>(IGitRevertCommandHandler, GitRevertCommandHandler);
 
     [IGitFileHistoryCommandHandler, IGitBranchFromCommitCommandHandler, IGitHistoryCommandHandler,
         IGitCommitCommandHandler, IGitCherryPickCommandHandler, IGitCompareFileCommandHandler,
         IGitCommitViewExplorerCommandHandler, IGitCompareCommitViewExplorerCommandHandler,
-        IFileCommandHandler, IGitRevertCommandHandler].forEach(serviceIdentifier => {
+        IFileCommandHandler, IGitMergeCommandHandler, IGitRevertCommandHandler].forEach(serviceIdentifier => {
             const instance = serviceManager.get<ICommandHandler>(serviceIdentifier);
             serviceManager.addSingletonInstance<ICommandHandler>(ICommandHandler, instance);
         });

--- a/src/commandHandlers/types.ts
+++ b/src/commandHandlers/types.ts
@@ -61,9 +61,13 @@ export interface IGitCherryPickCommandHandler extends ICommandHandler {
 }
 
 export const IGitMergeCommandHandler = Symbol('IGitMergeCommandHandler');
-// tslint:disable-next-line:no-empty-interface
 export interface IGitMergeCommandHandler extends ICommandHandler {
     merge(commit: CommitDetails): Promise<void>;
+}
+
+export const IGitRebaseCommandHandler = Symbol('IGitRebaseCommandHandler');
+export interface IGitRebaseCommandHandler extends ICommandHandler {
+    rebase(commit: CommitDetails): Promise<void>;
 }
 
 export const IGitRevertCommandHandler = Symbol('IGitRevertCommandHandler');

--- a/src/commandHandlers/types.ts
+++ b/src/commandHandlers/types.ts
@@ -60,6 +60,12 @@ export interface IGitCherryPickCommandHandler extends ICommandHandler {
     cherryPickCommit(commit: CommitDetails): Promise<void>;
 }
 
+export const IGitMergeCommandHandler = Symbol('IGitMergeCommandHandler');
+// tslint:disable-next-line:no-empty-interface
+export interface IGitMergeCommandHandler extends ICommandHandler {
+    merge(commit: CommitDetails): Promise<void>;
+}
+
 export const IGitRevertCommandHandler = Symbol('IGitRevertCommandHandler');
 // tslint:disable-next-line:no-empty-interface
 export interface IGitRevertCommandHandler extends ICommandHandler {

--- a/src/commands/commit/merge.ts
+++ b/src/commands/commit/merge.ts
@@ -1,0 +1,15 @@
+import { IGitMergeCommandHandler } from '../../commandHandlers/types';
+import { CommitDetails } from '../../common/types';
+import { BaseCommitCommand } from '../baseCommitCommand';
+
+export class MergeCommand extends BaseCommitCommand {
+    constructor(commit: CommitDetails, private handler: IGitMergeCommandHandler) {
+        super(commit);
+        this.setTitle(`$(git-merge) Merge this (${commit.logEntry.hash.short}) commit into current branch`);
+        this.setCommand('git.commit.merge');
+        this.setCommandArguments([commit]);
+    }
+    public execute() {
+        this.handler.merge(this.data);
+    }
+}

--- a/src/commands/commit/rebase.ts
+++ b/src/commands/commit/rebase.ts
@@ -1,0 +1,15 @@
+import { IGitRebaseCommandHandler } from '../../commandHandlers/types';
+import { CommitDetails } from '../../common/types';
+import { BaseCommitCommand } from '../baseCommitCommand';
+
+export class RebaseCommand extends BaseCommitCommand {
+    constructor(commit: CommitDetails, private handler: IGitRebaseCommandHandler) {
+        super(commit);
+        this.setTitle(`$(git-merge) Rebase current branch onto this (${commit.logEntry.hash.short}) commit`);
+        this.setCommand('git.commit.rebase');
+        this.setCommandArguments([commit]);
+    }
+    public execute() {
+        this.handler.rebase(this.data);
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,7 @@ export interface IGitService {
     createBranch(branchName: string, hash: string): Promise<void>;
     getOriginType(): Promise<GitOriginType | undefined>;
     merge(hash: string): Promise<void>;
+    rebase(hash: string): Promise<void>;
 }
 
 export type CommitComparison = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export interface IGitService {
     cherryPick(hash: string): Promise<void>;
     createBranch(branchName: string, hash: string): Promise<void>;
     getOriginType(): Promise<GitOriginType | undefined>;
+    merge(hash: string): Promise<void>;
 }
 
 export type CommitComparison = {


### PR DESCRIPTION
This PR adds a merge and a rebase commands to the history view. The commands are available from a commit. They let the user merge the selected commit into the current branch or rebase the current branch onto the selected commit. It is possible to choose to merge either the commit or any of the branches pointing to that commit.