### PR TITLE
getGitReposInFolder: fix async folder filtering

### DIFF
--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -13,6 +13,7 @@ import { IFileStatParser, ILogParser } from '../parsers/types';
 import { ITEM_ENTRY_SEPARATOR, LOG_ENTRY_SEPARATOR, LOG_FORMAT_ARGS } from './constants';
 import { GitOriginType } from './index';
 import { IGitArgsService } from './types';
+import { asyncFilter } from '../../common/helpers';
 
 @injectable()
 export class Git implements IGitService {
@@ -426,7 +427,7 @@ export class Git implements IGitService {
                     .map(item => path.join(dir, item));
                 filteredItems.push(dir);
 
-                const folders = await Promise.all<string>(filteredItems.filter(async item => (await fs.stat(item)).isDirectory()));
+                const folders = await asyncFilter(filteredItems, async item => (await fs.stat(item)).isDirectory());
                 const gitRootArgs = this.gitArgsService.getGitRootArgs();
                 const gitRoots = (await Promise.all(folders.map(async item => {
                     try {

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -23,3 +23,11 @@ export function formatDate(date: Date) {
     const dateOptions = { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric', hour: 'numeric', minute: 'numeric' };
     return date.toLocaleString(lang, dateOptions);
 }
+
+export async function asyncFilter<T>(arr: T[], callback): Promise<T[]> {
+    return (
+        await Promise.all(arr.map(
+            async item => (await callback(item)) ? item : undefined)
+        )
+    ).filter(i => i !== undefined) as T[];
+}


### PR DESCRIPTION
Folder filtering in `Git.getGitReposInFolder()`
```js
const folders = await Promise.all<string>(filteredItems.filter(async item => (await fs.stat(item)).isDirectory()));
```
is not working as intended, because the `filter()` callback returns a `Promise`, which is a truthy value, so `filter()` just passes `filteredItems` through, and `Promise.all()` does the same (as the array values are strings, not `Promise`s), so in the end `folders` is a copy of `filteredItems`.

Fixes #143 .

Note: I adapted `asyncFilter()` implementation from [this StackOverflow answer](https://stackoverflow.com/a/46842181).