### PR TITLE
Fix fixFileUri() on Windows

### DIFF
--- a/browser/src/actions/results.ts
+++ b/browser/src/actions/results.ts
@@ -235,9 +235,14 @@ function fixDates(logEntry: LogEntry) {
         logEntry.committer.date = new Date(logEntry.committer.date);
     }
 }
+function isWinPath(path: string) {
+    return /^\/[a-z]:\//i.test(path);
+}
 function fixFileUri(item?: FsUri) {
     if (item && !item.fsPath && item.path) {
-        (item as any).fsPath = item.path;
+        (item as any).fsPath = isWinPath(item.path) ?
+            item.path.replace(/^\//, '').replace(/\//g, '\\') :
+            item.path;
     }
 }
 // tslint:disable-next-line:no-any


### PR DESCRIPTION
On Windows `Uri.path` looks like `/d:/work/codesandbox-client/packages/app/src/app/components/Preview/index.js`. Because [`fixFileUri()`](https://github.com/DonJayamanne/gitHistoryVSCode/blob/master/browser/src/actions/results.ts#L238) just copies `item.path` to `item.fsPath`, `fsPath` will be invalid, which in turn leads to some features (like ["Compare against previous version"](https://github.com/DonJayamanne/gitHistoryVSCode/issues/307)) not working.

Fixes #307, #296, #297, maybe others.