### PR TITLE
Workaround on Uri.fsPath getting '/' (slash) prefix

### DIFF
--- a/browser/src/actions/results.ts
+++ b/browser/src/actions/results.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { Dispatch } from 'redux';
 import { createAction } from 'redux-actions';
-import { FsUri } from '../../../src/types';
 import * as Actions from '../constants/resultActions';
 import { ActionedUser, Avatar, CommittedFile, LogEntriesResponse, LogEntry } from '../definitions';
 import { BranchesState, RootState } from '../reducers';
@@ -235,11 +234,6 @@ function fixDates(logEntry: LogEntry) {
         logEntry.committer.date = new Date(logEntry.committer.date);
     }
 }
-function fixFileUri(item?: FsUri) {
-    if (item && !item.fsPath && item.path) {
-        (item as any).fsPath = item.path;
-    }
-}
 // tslint:disable-next-line:no-any
 function fetchCommits(dispatch: Dispatch<any>, store: RootState, pageIndex?: number, pageSize?: number, searchText?: string, refreshData?: boolean, branchName?: string, author?: string) {
     // pageSize = pageSize || store.logEntries.pageSize;
@@ -284,7 +278,7 @@ function fetchCommits(dispatch: Dispatch<any>, store: RootState, pageIndex?: num
                     }*/
                 });
             }
-            fixFileUri(result.data.file);
+            //fixFileUri(result.data.file);
             dispatch(addResults(result.data));
             if (result.data && Array.isArray(result.data.items) && result.data.items.length > 0) {
                 fetchAvatars(result.data.items.map(item => item.author), dispatch, () => store);
@@ -304,12 +298,12 @@ function fetchCommit(dispatch: Dispatch<any>, store: RootState, hash: string) {
         .then((result: { data: LogEntry }) => {
             if (result.data) {
                 fixDates(result.data);
-                if (Array.isArray(result.data.committedFiles)) {
+                /*if (Array.isArray(result.data.committedFiles)) {
                     result.data.committedFiles.forEach(f => {
                         fixFileUri(f.oldUri);
                         fixFileUri(f.uri);
                     });
-                }
+                }*/
             }
             dispatch(updateCommit(result.data));
             if (result.data && result.data.author) {

--- a/browser/src/actions/results.ts
+++ b/browser/src/actions/results.ts
@@ -276,12 +276,12 @@ function fetchCommits(dispatch: Dispatch<any>, store: RootState, pageIndex?: num
             if (Array.isArray(result.data.items)) {
                 result.data.items.forEach(item => {
                     fixDates(item);
-                    if (Array.isArray(item.committedFiles)) {
+                    /*if (Array.isArray(item.committedFiles)) {
                         item.committedFiles.forEach(f => {
                             fixFileUri(f.oldUri);
                             fixFileUri(f.uri);
                         });
-                    }
+                    }*/
                 });
             }
             fixFileUri(result.data.file);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "githistory",
     "displayName": "Git History",
     "description": "View git log, file history, compare branches or commits",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "publisher": "donjayamanne",
     "author": {
         "name": "Don Jayamanne",

--- a/src/adapter/parsers/fileStat/parser.ts
+++ b/src/adapter/parsers/fileStat/parser.ts
@@ -142,6 +142,18 @@ export class FileStatParser implements IFileStatParser {
                 uri: Uri.file(path.join(gitRootPath, relativePath)),
                 oldUri
             };
+           
+            // uri.fsPath getter sporadically becomes a slash as prefix (E.g  "/z:/folder/subfolder").
+            // By fetching fsPath through the getter, the internal method _makeFsPath(this) immediate get called here
+            // and the fsPath is set correctly.
+            //
+            // PLEASE NOTE: While DEBUGGING the property is  always resolved correctly
+            fileInfo.uri.fsPath;
+
+            if (fileInfo.oldUri !== undefined) {
+                fileInfo.oldUri.fsPath;
+            }
+
             return fileInfo;
         })
             .filter(commitFile => commitFile !== undefined)

--- a/src/commandHandlers/file/file.ts
+++ b/src/commandHandlers/file/file.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { ICommandManager, IDocumentManager } from '../../application/types';
-import { FileCommitDetails } from '../../common/types';
 import { command } from '../registration';
 import { IFileCommandHandler } from '../types';
 import { isTextFile } from './mimeTypes';
@@ -12,9 +11,8 @@ export class FileCommandHandler implements IFileCommandHandler {
         @inject(IDocumentManager) private documentManager: IDocumentManager) { }
 
     @command('git.openFileInViewer', IFileCommandHandler)
-    public async openFile(file: Uri, fileCommit: FileCommitDetails): Promise<void> {
-        const fileUri = Uri.file(fileCommit.committedFile.uri.fsPath);
-        if (isTextFile(fileUri)) {
+    public async openFile(file: Uri): Promise<void> {
+        if (isTextFile(file)) {
             const doc = await this.documentManager.openTextDocument(file);
             await this.documentManager.showTextDocument(doc, { preview: true });
         } else {


### PR DESCRIPTION
Alternate to PR #314  which should make the fixFileUrl unnecessary I guess
I assume some path modification take place before fsPath() got initially called.

So the call immediately after Uri.file([...]) is called fixes it for me.

More details on _makeFsPath here:
https://github.com/Microsoft/vscode/blob/master/src/vs/base/common/uri.ts#L547

May also fix #307, #296, #297 and others.