### PR TITLE
Read current remote name (defaulting to origin)

### DIFF
--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -159,7 +159,12 @@ export class Git implements IGitService {
     @cache('IGitService')
     public async getOriginType(): Promise<GitOriginType | undefined> {
         try {
-            return await this.exec('remote', 'get-url', 'origin')
+            const remoteName = await this.exec('status', '-sb').then((branchDetails) => {
+                const matchResult = branchDetails.match(/.*\.\.\.(.*)\//);
+                return matchResult && matchResult[1] ? matchResult[1] : 'origin';
+            });
+
+            return await this.exec('remote', 'get-url', remoteName)
                 .then(url => {
                     if (url.indexOf('github.com/') > 0) {
                         return GitOriginType.github;


### PR DESCRIPTION
Hey, since i'm seeing the following dreaded error message in the Output panel

    [...]
    git remote get-url origin  (completed in 0.011s)
    fatal: No such remote 'origin'

This happens when there are no remotes called origin (_am I the only way that gives descriptive names to remotes?_). I tried to look into the issue, and came up with this pull request. It is in no way tested, since I don't know how to "compile" an extension for testing. So take it as it is and fix it in case, or tell me what I need to change.