### PR TITLE
Fix GitHub origin detection for SSH remotes

### DIFF
--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -161,7 +161,7 @@ export class Git implements IGitService {
         try {
             return await this.exec('remote', 'get-url', 'origin')
                 .then(url => {
-                    if (url.indexOf('github.com/') > 0) {
+                    if (url.indexOf('github.com') > 0) {
                         return GitOriginType.github;
                     } else if (url.indexOf('bitbucket') > 0) {
                         return GitOriginType.bitbucket;


### PR DESCRIPTION
Fixes #312 

SSH URLs don't have slashes after the domain.