### PR TITLE
Match remote name lazily (fixes #331)

### DIFF
--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -161,7 +161,7 @@ export class Git implements IGitService {
     public async getOriginType(): Promise<GitOriginType | undefined> {
         try {
             const remoteName = await this.exec('status', '--porcelain=v1', '-b', '--untracked-files=no').then((branchDetails) => {
-                const matchResult = branchDetails.match(/.*\.\.\.(.*)\//);
+                const matchResult = branchDetails.match(/.*\.\.\.(.*?)\//);
                 return matchResult && matchResult[1] ? matchResult[1] : 'origin';
             });
 


### PR DESCRIPTION
Prevents inclusion of branch name in the case of slash delimited branches (fixes #331).

E.g., currently matches `origin/feature/some-change` as `origin/feature`. Will now match just `origin`.