### PR TITLE
History for submodules in subdirectories

### DIFF
--- a/src/adapter/repository/git.d.ts
+++ b/src/adapter/repository/git.d.ts
@@ -1,0 +1,221 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Uri, SourceControlInputBox, Event, CancellationToken } from 'vscode';
+
+export interface Git {
+    readonly path: string;
+}
+
+export interface InputBox {
+    value: string;
+}
+
+export const enum RefType {
+    Head,
+    RemoteHead,
+    Tag
+}
+
+export interface Ref {
+    readonly type: RefType;
+    readonly name?: string;
+    readonly commit?: string;
+    readonly remote?: string;
+}
+
+export interface UpstreamRef {
+    readonly remote: string;
+    readonly name: string;
+}
+
+export interface Branch extends Ref {
+    readonly upstream?: UpstreamRef;
+    readonly ahead?: number;
+    readonly behind?: number;
+}
+
+export interface Commit {
+    readonly hash: string;
+    readonly message: string;
+    readonly parents: string[];
+}
+
+export interface Submodule {
+    readonly name: string;
+    readonly path: string;
+    readonly url: string;
+}
+
+export interface Remote {
+    readonly name: string;
+    readonly fetchUrl?: string;
+    readonly pushUrl?: string;
+    readonly isReadOnly: boolean;
+}
+
+export const enum Status {
+    INDEX_MODIFIED,
+    INDEX_ADDED,
+    INDEX_DELETED,
+    INDEX_RENAMED,
+    INDEX_COPIED,
+
+    MODIFIED,
+    DELETED,
+    UNTRACKED,
+    IGNORED,
+    INTENT_TO_ADD,
+
+    ADDED_BY_US,
+    ADDED_BY_THEM,
+    DELETED_BY_US,
+    DELETED_BY_THEM,
+    BOTH_ADDED,
+    BOTH_DELETED,
+    BOTH_MODIFIED
+}
+
+export interface Change {
+
+    /**
+     * Returns either `originalUri` or `renameUri`, depending
+     * on whether this change is a rename change. When
+     * in doubt always use `uri` over the other two alternatives.
+     */
+    readonly uri: Uri;
+    readonly originalUri: Uri;
+    readonly renameUri: Uri | undefined;
+    readonly status: Status;
+}
+
+export interface RepositoryState {
+    readonly HEAD: Branch | undefined;
+    readonly refs: Ref[];
+    readonly remotes: Remote[];
+    readonly submodules: Submodule[];
+    readonly rebaseCommit: Commit | undefined;
+
+    readonly mergeChanges: Change[];
+    readonly indexChanges: Change[];
+    readonly workingTreeChanges: Change[];
+
+    readonly onDidChange: Event<void>;
+}
+
+export interface RepositoryUIState {
+    readonly selected: boolean;
+    readonly onDidChange: Event<void>;
+}
+
+export interface Repository {
+
+    readonly rootUri: Uri;
+    readonly inputBox: InputBox;
+    readonly state: RepositoryState;
+    readonly ui: RepositoryUIState;
+
+    getConfigs(): Promise<{ key: string; value: string; }[]>;
+    getConfig(key: string): Promise<string>;
+    setConfig(key: string, value: string): Promise<string>;
+
+    getObjectDetails(treeish: string, path: string): Promise<{ mode: string, object: string, size: number }>;
+    detectObjectType(object: string): Promise<{ mimetype: string, encoding?: string }>;
+    buffer(ref: string, path: string): Promise<Buffer>;
+    show(ref: string, path: string): Promise<string>;
+    getCommit(ref: string): Promise<Commit>;
+
+    clean(paths: string[]): Promise<void>;
+
+    apply(patch: string, reverse?: boolean): Promise<void>;
+    diff(cached?: boolean): Promise<string>;
+    diffWithHEAD(path: string): Promise<string>;
+    diffWith(ref: string, path: string): Promise<string>;
+    diffIndexWithHEAD(path: string): Promise<string>;
+    diffIndexWith(ref: string, path: string): Promise<string>;
+    diffBlobs(object1: string, object2: string): Promise<string>;
+    diffBetween(ref1: string, ref2: string, path: string): Promise<string>;
+
+    hashObject(data: string): Promise<string>;
+
+    createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
+    deleteBranch(name: string, force?: boolean): Promise<void>;
+    getBranch(name: string): Promise<Branch>;
+    setBranchUpstream(name: string, upstream: string): Promise<void>;
+
+    getMergeBase(ref1: string, ref2: string): Promise<string>;
+
+    status(): Promise<void>;
+    checkout(treeish: string): Promise<void>;
+
+    addRemote(name: string, url: string): Promise<void>;
+    removeRemote(name: string): Promise<void>;
+
+    fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
+    pull(unshallow?: boolean): Promise<void>;
+    push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
+    blame(path: string): Promise<string>;
+}
+
+export interface API {
+    readonly git: Git;
+    readonly repositories: Repository[];
+    readonly onDidOpenRepository: Event<Repository>;
+    readonly onDidCloseRepository: Event<Repository>;
+}
+
+export interface GitExtension {
+
+    readonly enabled: boolean;
+    readonly onDidChangeEnablement: Event<boolean>;
+
+    /**
+     * Returns a specific API version.
+     *
+     * Throws error if git extension is disabled. You can listed to the
+     * [GitExtension.onDidChangeEnablement](#GitExtension.onDidChangeEnablement) event
+     * to know when the extension becomes enabled/disabled.
+     *
+     * @param version Version number.
+     * @returns API instance
+     */
+    getAPI(version: 1): API;
+}
+
+export const enum GitErrorCodes {
+    BadConfigFile = 'BadConfigFile',
+    AuthenticationFailed = 'AuthenticationFailed',
+    NoUserNameConfigured = 'NoUserNameConfigured',
+    NoUserEmailConfigured = 'NoUserEmailConfigured',
+    NoRemoteRepositorySpecified = 'NoRemoteRepositorySpecified',
+    NotAGitRepository = 'NotAGitRepository',
+    NotAtRepositoryRoot = 'NotAtRepositoryRoot',
+    Conflict = 'Conflict',
+    StashConflict = 'StashConflict',
+    UnmergedChanges = 'UnmergedChanges',
+    PushRejected = 'PushRejected',
+    RemoteConnectionError = 'RemoteConnectionError',
+    DirtyWorkTree = 'DirtyWorkTree',
+    CantOpenResource = 'CantOpenResource',
+    GitNotFound = 'GitNotFound',
+    CantCreatePipe = 'CantCreatePipe',
+    CantAccessRemote = 'CantAccessRemote',
+    RepositoryNotFound = 'RepositoryNotFound',
+    RepositoryIsLocked = 'RepositoryIsLocked',
+    BranchNotFullyMerged = 'BranchNotFullyMerged',
+    NoRemoteReference = 'NoRemoteReference',
+    InvalidBranchName = 'InvalidBranchName',
+    BranchAlreadyExists = 'BranchAlreadyExists',
+    NoLocalChanges = 'NoLocalChanges',
+    NoStashFound = 'NoStashFound',
+    LocalChangesOverwritten = 'LocalChangesOverwritten',
+    NoUpstreamBranch = 'NoUpstreamBranch',
+    IsInSubmodule = 'IsInSubmodule',
+    WrongCase = 'WrongCase',
+    CantLockRef = 'CantLockRef',
+    CantRebaseMultipleBranches = 'CantRebaseMultipleBranches',
+    PatchDoesNotApply = 'PatchDoesNotApply',
+    NoPathFound = 'NoPathFound'
+}

--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Writable } from 'stream';
 import * as tmp from 'tmp';
-import { Uri } from 'vscode';
+import { Uri, extensions } from 'vscode';
 import { IWorkspaceService } from '../../application/types/workspace';
 import { cache } from '../../common/cache';
 import { IServiceContainer } from '../../ioc/types';
@@ -11,9 +11,9 @@ import { ActionedUser, Branch, CommittedFile, FsUri, Hash, IGitService, LogEntri
 import { IGitCommandExecutor } from '../exec';
 import { IFileStatParser, ILogParser } from '../parsers/types';
 import { ITEM_ENTRY_SEPARATOR, LOG_ENTRY_SEPARATOR, LOG_FORMAT_ARGS } from './constants';
+import { GitExtension } from './git.d';
 import { GitOriginType } from './index';
 import { IGitArgsService } from './types';
-import { asyncFilter } from '../../common/helpers';
 
 @injectable()
 export class Git implements IGitService {
@@ -57,7 +57,14 @@ export class Git implements IGitService {
             return [];
         }
 
-        const gitFoldersList = await Promise.all(rootDirectories.map(item => this.getGitReposInFolder(item)));
+        // Instead of traversing the directory structure for the entire workspace, use the Git extension API to get all repo paths
+        const gitExtension = extensions.getExtension<GitExtension>('vscode.git')!.exports;
+        const git = gitExtension.getAPI(1);
+
+        const sourceControlFolders: string[] = git.repositories.map(repo => { return repo.rootUri.path; });
+        sourceControlFolders.sort();
+        // gitFoldersList should be an Array of Arrays
+        const gitFoldersList = [sourceControlFolders];
         const gitRoots = new Set<string>();
         gitFoldersList
             .reduce<string[]>((aggregate, items) => { aggregate.push(...items); return aggregate; }, [])
@@ -422,60 +429,6 @@ export class Git implements IGitService {
     private async execBinary(destination: Writable, ...args: string[]): Promise<void> {
         const gitRootPath = await this.getGitRoot();
         return this.gitCmdExecutor.exec({ cwd: gitRootPath, encoding: 'binary' }, destination, ...args);
-    }
-    private async getGitReposInFolder(dir: string): Promise<string[]> {
-        const folders = await this.getSubfoldersToScan(dir);
-
-        const gitRootArgs = this.gitArgsService.getGitRootArgs();
-        const gitRoots = (await Promise.all(folders.map(async item => {
-            try {
-                const result = await this.gitCmdExecutor.exec(item, ...gitRootArgs);
-                return path.normalize(result.split(/\r?\n/g)[0].trim());
-            } catch {
-                return;
-            }
-        })))
-            .filter(item => !!item)
-            .map(item => item!)
-            // Ensure each git repo is only added once 
-            .filter((item, idx, arr) => { return (arr.indexOf(item) == idx); });
-
-        return gitRoots;
-    }
-    private async getSubfoldersToScan(dir: string): Promise<string[]> {
-        return new Promise<string[]>(resolve => {
-            fs.readdir(dir, async (err, filesAndFolders) => {
-                if (err) {
-                    return resolve([]);
-                }
-                // Lets ignore folders begining with '.' (hopeufully no one will have them).
-                // Ignore python virtual environments, etc.
-                const filteredItems = filesAndFolders
-                    .filter(item => !item.startsWith('.'))
-                    .map(item => path.join(dir, item));
-
-                // Filter out all files
-                let folders = await asyncFilter(filteredItems, async item => (await fs.stat(item)).isDirectory());
-                if (folders.length > 0) {
-                    // Traverse all subfolders to generate a list of the entire directory structure
-                    // This ensures all git submodules - that have been pulled - will be detected
-                    const subfolders = await Promise.all(folders.map(folder => this.getSubfoldersToScan(folder)));
-                    subfolders.forEach(folderList => {
-                        // Add each subfolder found
-                        folderList.forEach(folder => {
-                            if (folders.indexOf(folder) < 0)
-                                folders.push(folder);
-                        });
-                    });
-                }
-
-                // Add the search folder to the list
-                if (folders.indexOf(dir) < 0)
-                    folders.push(dir);
-
-                resolve(folders);
-            });
-        });
     }
 
     // how to check if a commit has been merged into any other branch


### PR DESCRIPTION
Provides history for submodules in subdirectories or nested in other submodules.
Resolves Issue #277.

This uses the now-available API in VS Code's built-in Git extension to get all detected repos in the workspace, and use their paths as the list of known repo paths.
[Per the API documentation](https://github.com/Microsoft/vscode/blob/master/extensions/git/README.md), the built-in Git's *[git.d.ts](https://github.com/Microsoft/vscode/blob/master/extensions/git/src/api/git.d.ts)* file is included in this PR, but may be more logical to locate elsewhere for use throughout this extension.

I did also try scanning subdirectories per the existing method, but on a large directory hierarchy - like this extension - it's just too slow.  There are two commits in the PR, and the first one ([63fbdac](https://github.com/DonJayamanne/gitHistoryVSCode/commit/63fbdacbe4f2c4140c064509bcd5594840f333a4)) is that method if anyone is curious to work with it.