### PR TITLE
Style the extension according to selected Color Theme

### DIFF
--- a/browser/src/color-theme-dark.css
+++ b/browser/src/color-theme-dark.css
@@ -100,3 +100,15 @@ slick-grid.active .grid .slick-cell.selected {
 .shortCut {
   color: grey;
 }
+
+.close-btn {
+    color: white;
+}
+
+.log-entry {
+	border-bottom: 1px solid hsla(0, 0%, 100%, .3);
+}
+
+div.details-view-cnt {
+    border-top: 1px solid hsla(0, 0%, 100%, .3);
+}

--- a/browser/src/color-theme-light.css
+++ b/browser/src/color-theme-light.css
@@ -105,3 +105,15 @@ slick-grid.active .grid .slick-cell.selected {
 .shortCut {
   color: grey;
 }
+
+.close-btn {
+    color: black;
+}
+
+.log-entry {
+	border-bottom: 1px solid hsla(0, 0%, 0%, .2);
+}
+
+div.details-view-cnt {
+    border-top: 1px solid hsla(0, 0%, 0%, .2);
+}

--- a/browser/src/components/Footer/index.tsx
+++ b/browser/src/components/Footer/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Button } from 'react-bootstrap';
 
 type FooterProps = {
     canGoForward: boolean;
@@ -9,20 +10,14 @@ type FooterProps = {
 export default function Footer(props: FooterProps) {
     return (
         <div id='history-navbar'>
-            <ul className='navbar'>
-                <li className={'navbar-item previous ' + (props.canGoBack ? '' : 'disabled')}>
-                    <a href='javascript:void(0);' className='navbar-link' onClick={() => props.goBack()}>
-                        <i className='octicon octicon-chevron-left'></i>
-                        <span>Previous</span>
-                    </a>
-                </li>
-                <li className={'navbar-item next ' + (props.canGoForward ? '' : 'disabled')}>
-                    <a href='javascript:void(0);' className='navbar-link' onClick={() => props.goForward()}>
-                        <span>Next</span>
-                        <i className='octicon octicon-chevron-right'></i>
-                    </a>
-                </li>
-            </ul>
+            <Button bsStyle='primary' className='navbar-link' className={props.canGoBack ? '' : 'disabled'} onClick={() => props.goBack()}>
+                <i className='octicon octicon-chevron-left'></i>
+                <span>Previous</span>
+            </Button>
+            <Button bsStyle='primary' className='navbar-link' lassName={props.canGoForward ? '' : 'disabled'} onClick={() => props.goForward()}>
+                <span>Next</span>
+                <i className='octicon octicon-chevron-right'></i>
+            </Button>
         </div>
     );
 }

--- a/browser/src/components/Header/index.tsx
+++ b/browser/src/components/Header/index.tsx
@@ -53,9 +53,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 
     // tslint:disable-next-line:member-ordering
     public render() {
-        const style = { color: 'black' };
         return (<header>
-            <input type="text" value={this.state.searchText} style={style} onChange={this.handleSearchChange} />
+            <input className={'textInput'} type="text" value={this.state.searchText} placeholder="Search…" onChange={this.handleSearchChange} />
             <Button
                 bsStyle='primary' bsSize='small'
                 disabled={this.state.isLoading}

--- a/browser/src/components/LogView/Commit/Author/index.tsx
+++ b/browser/src/components/LogView/Commit/Author/index.tsx
@@ -24,7 +24,7 @@ function formatDateTime(locale: string, date?: Date) {
     const dateOptions = { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric', hour: 'numeric', minute: 'numeric' };
     try {
         locale = typeof locale === 'string' ? locale.replace('_', '-') : locale;
-        return date.toLocaleString(locale, dateOptions);
+        return date.toLocaleString(locale);
     } catch {
         return date.toLocaleString(undefined, dateOptions);
     }

--- a/browser/src/components/LogView/Commit/index.tsx
+++ b/browser/src/components/LogView/Commit/index.tsx
@@ -31,25 +31,16 @@ class Commit extends React.Component<CommitProps> {
         if (this.props && this.props.selectedEntry) {
             setTimeout(this.resize.bind(this), 1);
         }
-        else {
-            jQuery('#placeHolderCommit').hide();
-        }
     }
     public componentDidMount() {
         if (this.props && this.props.selectedEntry) {
             setTimeout(this.resize.bind(this), 1);
         }
     }
-    public componentWillUnmount() {
-        jQuery('#placeHolderCommit').hide();
-    }
     private resize() {
         const $ref = jQuery('.react-draggable');
         $ref.removeClass('hidden').css('top', '');
         jQuery('#details-view').removeClass('hidden');
-        const height = $ref.height();
-
-        jQuery('#placeHolderCommit').css('padding-top', height / 2).css('padding-bottom', (height / 2) + 10).show();
     }
     private ref: HTMLElement;
     private onSelectFile = (fileEntry: CommittedFile) => {
@@ -62,19 +53,7 @@ class Commit extends React.Component<CommitProps> {
         return this.props.selectedEntry.committedFiles
             .map((fileEntry, index) => <FileEntry theme={this.props.theme} committedFile={fileEntry} key={index + fileEntry.relativePath} onSelect={this.onSelectFile} />);
     }
-
-    private onResize = (_, direction: Direction, ref: HTMLElement, delta: number) => {
-        const $ref = jQuery(ref);
-        const height = $ref.height();
-        const padding = height / 2;
-        jQuery('#placeHolderCommit').show().css('padding-top', padding).css('padding-bottom', padding);
-    }
     public render() {
-        if (!this.props.selectedEntry) {
-            jQuery('#placeHolderCommit').hide();
-            return null;
-        }
-
         const resizing = { top: true, right: false, bottom: false, left: false, topRight: false, bottomRight: false, bottomLeft: false, topLeft: false };
 
         return (

--- a/browser/src/components/LogView/LogEntry/index.tsx
+++ b/browser/src/components/LogView/LogEntry/index.tsx
@@ -76,8 +76,8 @@ function LogEntry(props: ResultListProps) {
             {renderHeadRef(props.logEntry.refs)}
             {renderTagRef(props.logEntry.refs)}
             <div role='button' className='media-content' onClick={() => props.onViewCommit(props.logEntry)}>
-                <Avatar result={props.logEntry.author}></Avatar>
                 <div className='commit-subject' title={gitmojify(props.logEntry.subject)}>{gitmojify(props.logEntry.subject)}</div>
+                <Avatar result={props.logEntry.author}></Avatar>
                 <Author result={props.logEntry.author}></Author>
             </div>
         </div>

--- a/browser/src/containers/App/index.tsx
+++ b/browser/src/containers/App/index.tsx
@@ -38,7 +38,6 @@ class App extends React.Component<AppProps, AppState> {
                 <div className='appRoot'>
                     <Header></Header >
                     <LogView logEntries={ this.props.logEntries }></LogView>
-                    <div id='placeHolderCommit'></div>
                     <Footer
                         canGoBack={ this.props.logEntries.pageIndex > 0 }
                         canGoForward={ canGoForward }

--- a/browser/src/index.ejs
+++ b/browser/src/index.ejs
@@ -6,30 +6,13 @@
     <link rel='stylesheet' type='text/css' href='bootstrap.min.css' />
     <link rel="stylesheet" href="normalize.css" >
     <style>
-        :root {
-            --background-color: <%=backgroundColor%>;
-            --color: <%=color%>;
-            --font-family: <%=fontFamily%>;
-            --font-weight: <%=fontWeight%>;
-            --font-size: <%=fontSize%>;
-        }
-        body {
-            background-color: <%=backgroundColor%>;
-            color: <%=color%>;
-            font-family: <%=fontFamily%>;
-            font-weight: <%=fontWeight%>;
-            font-size: <%=fontSize%>;
-        }
-        html, body {
-            line-height: 1.15;
-            /* 2 */
-        }
+        <%=styles%>
     </style>
     <link rel="stylesheet" href='animate.min.css' >
     <link rel="stylesheet" href='hint.min.css' >
     <link rel='stylesheet' type='text/css' href='main.css' />
     <link rel='stylesheet' type='text/css' href='octicons.min.css' />
-    
+
     <%if (theme === 'vscode-light') { %>
     <link rel="stylesheet" type="text/css" href="/color-theme-light.css"/>
     <%} else { %>

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -11,7 +11,7 @@ body {
 	margin: 0;
 	font-family: -apple-system, BlinkMacSystemFont, Segoe WPC, Segoe UI, HelveticaNeue-Light, Ubuntu, Droid Sans, sans-serif;
 	padding: 0;
-	overflow: hidden;
+    overflow: hidden;
 }
 
 html {
@@ -55,6 +55,7 @@ body {
 .media .media-image {
 	margin: 0 1em 0 0;
 }
+
 .xxsss{
 	background-image: url('../resources/icons/dark/status-added.svg')
 }
@@ -69,7 +70,7 @@ body {
 }
 
 .media.right .media-image {
-	margin: 0 0 0 1em;
+	margin: 0.8em 0.5em 0 0;
 }
 
 div.appRootParent {
@@ -126,9 +127,7 @@ div.appRoot {
 }
 
 .log-entry {
-	padding: 0.5em;
 	position: relative;
-	border-bottom: 1px solid hsla(0, 0%, 100%, 0.3);
 }
 
 .log-entry .media-content {
@@ -136,6 +135,7 @@ div.appRoot {
 	overflow: hidden;
     cursor: pointer;
     min-width: 15em;
+    padding: 0.5em;
 }
 
 .log-entry .media-image {
@@ -168,10 +168,10 @@ div.appRoot {
 }
 
 .log-entry img.avatar {
-	height:30px;
-    width:30px;
+	height:15px;
+    width:15px;
     float:left;
-    margin-right:0.5em;
+    margin:0.2em 0.4em 0.2em 0;
 }
 
 .authorAndCommitInfoContainer {
@@ -179,8 +179,8 @@ div.appRoot {
     width:100%;
 }
 .authorAndCommitInfoContainer img.avatar {
-    height: 150px;
-    width: 150px;
+    height: 42px;
+    width: 42px;
     float: left;
     margin-right: 0.5em;
 }
@@ -204,21 +204,28 @@ div.appRoot {
 }
 
 .commit-hash-container {
-	background-color: hsla(204, 80%, 40%, 1);
-	white-space: nowrap;
+    background-color: var(--vscode-inputValidation-infoBackground);
+    color: var(--vscode-input-foreground);
+    white-space: nowrap;
+}
+
+.commit-remote-container,
+.commit-tag-container,
+.commit-head-container {
+    border-radius: 5px;
 }
 
 .commit-head-container {
-	background-color: #438a43;
+	background-color: var(--vscode-editorGutter-addedBackground);
 	white-space: nowrap;
 }
 
 .commit-remote-container {
-	background-color: #7d3d40;
+	background-color: var(--vscode-editorGutter-deletedBackground);
 }
 
 .commit-tag-container {
-	background-color: gray;
+	background-color: var(--vscode-terminal-ansiBrightBlack);
 }
 
 .commit-remote-container .refs,
@@ -227,7 +234,7 @@ div.appRoot {
 	display: block;
 	color: white;
 	font-size: 75%;
-    padding: 0.3em;
+    padding: 0.25em 0.5em;
     display: flex;
 }
 
@@ -242,21 +249,25 @@ div.appRoot {
 .commit-remote-container .refs span:first-of-type,
 .commit-tag-container .refs span:first-of-type,
 .commit-head-container .refs span:first-of-type {
-    padding-right:0.5em;
+    padding-right: 0.2em;
 }
 
 .commit-hash-container .commit-hash,
 .commit-hash-container .copy-button {
 	display: inline-block;
-	color: white;
-	padding: 0.4em;
+	color: var(--vscode-input-foreground);
+	padding: 0.2em;
 	cursor: pointer;
 }
 
 .commit-hash-container .cherry-pick-button {
 	display: inline-block;
-	color: white;
-	padding: 0.4em;
+	color: var(--vscode-input-foreground);
+	padding: 0.2em;
+}
+
+.commit-hash-container .commit-hash {
+	padding-right: 0.4em;
 }
 
 .cherry-pick-button a,
@@ -266,13 +277,13 @@ div.appRoot {
 
 .commit-hash-container .cherry-pick-button {
 	display: inline-block;
-	color: white;
-	padding: 0.4em;
+	color: var(--vscode-input-foreground);
+	padding: 0.2em;
 }
 
 .cherry-pick-button a,
 .cherry-pick-button a:hover {
-	color: white;
+	color: var(--vscode-input-foreground);
 }
 
 .commit-hash-container .commit-hash:hover {
@@ -282,7 +293,7 @@ div.appRoot {
 .commit-hash-container .copy-button {
 	position: relative;
 	/* compensate for octicon margin */
-	padding-left: 0.8em;
+	padding-left: 0.6em;
 }
 
 .copy-button .clipboard {
@@ -311,15 +322,15 @@ div.appRoot {
 }
 
 .log-entry.active .commit-hash-container {
-	background-color: yellowgreen;
+	background-color: var(--vscode-inputValidation-infoBackground);
 }
 
 .log-entry.active .commit-subject {
-	color: yellowgreen;
+	color: var(--vscode-textLink-foreground);
 }
 
 .log-entry.active .commit-author {
-	color: yellowgreen;
+	color: var(--vscode-textLink-foreground);
 }
 
 header {
@@ -336,7 +347,7 @@ header input, header button {
 #history-navbar {
 	text-align: right;
 	/* Approximation for scroll bar width of 15px*/
-	margin: 0em 1.3em 0.5em 0.5em;
+	margin: 0.5em 1em;
 }
 
 #history-navbar .navbar {
@@ -425,8 +436,7 @@ header input, header button {
 	display:none;
 }
 .detailsCnt {
-	overflow: auto;
-	border-top: 1px solid hsla(0, 0%, 100%, 0.50);
+    overflow: auto;
 }
 #details-view {
 	/* position: absolute;
@@ -471,7 +481,7 @@ div.commitCntDrag {
 div.react-draggable.react-draggable-dragged,
 div.react-draggable {
 	width: 100% !important;
-	bottom: 35px !important;
+	bottom: 45px !important;
 	position: absolute;
 }
 
@@ -491,7 +501,9 @@ div.react-draggable {
 
 div.details-view-cnt {
 	bottom: 30px;
-	overflow-x: hidden;
+    overflow-x: hidden;
+    background: var(--vscode-editor-background);
+    border-top: 1px solid hsla(0, 0%, 100%, 0.50);
 	max-height: 50vh !important;
 }
 
@@ -571,11 +583,11 @@ div.details-view-cnt {
 }
 
 .diff-block.added {
-	background-color: green;
+	background-color: var(--vscode-terminal-ansiGreen);
 }
 
 .diff-block.deleted {
-	background-color: maroon;
+	background-color: var(--vscode-terminal-ansiRed);
 }
 
 
@@ -611,8 +623,58 @@ div.details-view-cnt {
 	display: block;
 }
 
-.dropdown-menu {
+.dropdow§n-menu {
     max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;
 }
+
+.btn {
+    color: var(--vscode-input-foreground);
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-background);
+    border-radius: 0;
+}
+
+.btn:focus {
+    border: var(--vscode-focusBorder);
+}
+
+.btn-group-sm>.btn, .btn-sm {
+    border-radius: 0;
+}
+
+.btn:hover {
+    color: var(--vscode-breadcrumb-focusForeground);
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-focusBorder);
+}
+
+.btn-warning:hover {
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-inputValidation-warningBorder);
+}
+
+.btn-info:hover {
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-inputValidation-infoBorder);
+}
+
+.textInput {
+    position: relative;
+    top: 1px;
+    left: 2px;
+    font-size: 12px;
+    line-height: 1.5;
+    padding: 5px 10px;
+    color: var(--vscode-input-foreground);
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-background);
+    border-radius: 0;
+}
+
+.textInput:focus {
+    outline: none;
+    border: 1px solid var(--vscode-focusBorder);
+}
+

--- a/src/server/contentProvider.ts
+++ b/src/server/contentProvider.ts
@@ -41,7 +41,7 @@ export class ContentProvider implements TextDocumentContentProvider {
         return `
                     <!DOCTYPE html>
                     <head><style type="text/css"> html, body{ height:100%; width:100%; overflow:hidden; padding:0;margin:0; } </style>
-                    <titleCan I give a title</title>
+                    <title>Git History</title>
                     <script type="text/javascript">
                         function start(){
                             // We need a unique value so html is reloaded
@@ -50,6 +50,7 @@ export class ContentProvider implements TextDocumentContentProvider {
                             var fontSize = '';
                             var theme = '';
                             var fontWeight = '';
+                            var styles = '';
                             try {
                                 computedStyle = window.getComputedStyle(document.body);
                                 color = computedStyle.color + '';
@@ -58,6 +59,7 @@ export class ContentProvider implements TextDocumentContentProvider {
                                 fontSize = computedStyle.fontSize;
                                 fontWeight = computedStyle.fontWeight;
                                 theme = document.body.className;
+                                styles = document.getElementById('_defaultStyles').innerHTML;
                             }
                             catch(ex){
                             }
@@ -72,7 +74,8 @@ export class ContentProvider implements TextDocumentContentProvider {
                                             'fontFamily=' + encodeURIComponent(fontFamily),
                                             'fontWeight=' + encodeURIComponent(fontWeight),
                                             'fontSize=' + encodeURIComponent(fontSize),
-                                            'locale=${encodeURIComponent(locale)}'
+                                            'locale=${encodeURIComponent(locale)}',
+                                            'styles=' + encodeURIComponent(styles)
                                         ];
                             document.getElementById('myframe').src = 'http://localhost:${port}/?_=${timeNow}&' + queryArgs.join('&');
                         }

--- a/src/server/serverHost.ts
+++ b/src/server/serverHost.ts
@@ -78,10 +78,11 @@ export class ServerHost extends EventEmitter implements IServerHost {
         });
     }
     public rootRequestHandler(req: Request, res: Response) {
+        const styles: string = req.query.styles;
         const theme: string = req.query.theme;
         const backgroundColor: string = req.query.backgroundColor;
         const color: string = req.query.color;
-        const themeDetails = this.themeService.getThemeDetails(theme, backgroundColor, color);
+        const themeDetails = this.themeService.getThemeDetails(theme, backgroundColor, color, styles);
         res.render(path.join(__dirname, '..', '..', 'browser', 'index.ejs'), themeDetails);
     }
 }

--- a/src/server/themeService.ts
+++ b/src/server/themeService.ts
@@ -4,7 +4,7 @@ import { IThemeService, ThemeDetails } from './types';
 
 @injectable()
 export class ThemeService implements IThemeService {
-    public getThemeDetails(theme: string, backgroundColor: string, color: string): ThemeDetails {
+    public getThemeDetails(theme: string, backgroundColor: string, color: string, styles: string): ThemeDetails {
         const editorConfig = workspace.getConfiguration('editor');
         // tslint:disable-next-line:no-backbone-get-set-outside-model
         const fontFamily = editorConfig.get<string>('fontFamily')!.split('\'').join('').split('"').join('');
@@ -18,7 +18,8 @@ export class ThemeService implements IThemeService {
             color: color,
             fontFamily: fontFamily,
             fontSize: fontSize,
-            fontWeight: fontWeight
+            fontWeight: fontWeight,
+            styles: styles
         };
     }
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -4,6 +4,7 @@ import { BranchSelection, LogEntries, LogEntry } from '../types';
 
 export type ThemeDetails = {
     theme: string;
+    styles: string;
     backgroundColor: string;
     color: string;
     fontFamily: string;
@@ -13,7 +14,7 @@ export type ThemeDetails = {
 export const IThemeService = Symbol('IThemeService');
 
 export interface IThemeService {
-    getThemeDetails(theme: string, backgroundColor: string, color: string): ThemeDetails;
+    getThemeDetails(theme: string, backgroundColor: string, color: string, styles: string): ThemeDetails;
 }
 export const IApiRouteHandler = Symbol('IApiRouteHandler');
 


### PR DESCRIPTION
Fixes #249 and #309.

Quick and dirty fix, probably needs more work.

* Injects VSCode's [CSS Variables](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content) from the container `iframe` to the React `iframe`. (Is it necessary to run React in this inner `iframe`?)
* Removes `#placeHolderCommit` (jQuery may be no longer needed).
* Smaller avatars.
* Some design polish here and there, still not pixel perfect.
* I'm still not happy with some colors, but testing the CSS Variables in various themes one by one quickly becomes tedious. 
* Probably could get better results lightening or darkening existing colors.

Screenshots: https://imgur.com/a/XpLBGhH