### PR TITLE
Fixed styles being passed as URL argument 'style' with postMessage

### DIFF
--- a/browser/src/components/Header/index.tsx
+++ b/browser/src/components/Header/index.tsx
@@ -51,7 +51,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
         this.setState({ isLoading: this.state.isLoading, searchText: e.target.value });
     }
 
-    private handleKeyDown = (e: React.KeyboardEvent) => {
+    private handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
             this.onSearch();
         } else if (e.key === 'Escape') {

--- a/browser/src/index.ejs
+++ b/browser/src/index.ejs
@@ -10,12 +10,17 @@
     <link rel='stylesheet' type='text/css' href='main.css' />
     <link rel='stylesheet' type='text/css' href='octicons.min.css' />
 
-    <style>
-      :root {
-        <%=styles%>
-      }
+    <style id="_defaultStyles">
       
     </style>
+    <script>
+      function receiveMessage(event) {
+        console.log('Applying styles received from parent frame...');
+        document.getElementById('_defaultStyles').innerHTML = ':root { ' + event.data +  '  }';
+      }
+
+      window.addEventListener('message', receiveMessage, false);
+    </script>
 
     <%if (theme === 'vscode-light') { %>
     <link rel="stylesheet" type="text/css" href="/color-theme-light.css"/>

--- a/src/adapter/repository/gitArgsService.ts
+++ b/src/adapter/repository/gitArgsService.ts
@@ -24,26 +24,21 @@ export class GitArgsService implements IGitArgsService {
         return ['log', '--format=%p', '-n1', hash];
     }
     public getCommitWithNumStatArgs(hash: string) {
-        // return ['log', '--numstat', '--full-history', '--decorate=full', '-M', '--format=""', '-m', '-n1', hash];
         return ['show', '--numstat', '--format=', '-M', hash];
     }
     public getCommitNameStatusArgs(hash: string): string[] {
-        // return ['show', '--name-status', '--full-history', '-M', '--format=""', '-m', '-n1', hash];
         return ['show', '--name-status', '--format=', '-M', hash];
     }
     public getCommitWithNumStatArgsForMerge(hash: string) {
-        // return ['log', '--numstat', '--full-history', '--decorate=full', '-M', '--format=""', '-m', '-n1', hash];
         return ['show', '--numstat', '--format=', '-M', '--first-parent', hash];
     }
     public getCommitNameStatusArgsForMerge(hash: string): string[] {
-        // return ['show', '--name-status', '--full-history', '-M', '--format=""', '-m', '-n1', hash];
         return ['show', '--name-status', '--format=', '-M', '--first-parent', hash];
     }
     public getObjectHashArgs(object: string): string[] {
         return ['show', `--format=${Helpers.GetCommitInfoFormatCode(CommitInfo.FullHash)}`, '--shortstat', object];
     }
     public getRefsContainingCommitArgs(hash: string): string[] {
-        // return ['branch', '--branches', '--tags', '--remotes', '--contains', hash];
         return ['branch', '--all', '--contains', hash];
     }
     public getAuthorsArgs(): string[] {

--- a/src/server/contentProvider.ts
+++ b/src/server/contentProvider.ts
@@ -45,24 +45,23 @@ export class ContentProvider implements TextDocumentContentProvider {
                     <head><style type="text/css"> html, body{ height:100%; width:100%; overflow:hidden; padding:0;margin:0; } </style>
                     <title>Git History</title>
                     <script type="text/javascript">
-                        function start(){
-                            // We need a unique value so html is reloaded
-                            try {
-                                theme = document.body.className;
-                                styles = document.getElementsByTagName("html")[0].style.cssText;
-                            }
-                            catch(ex){
-                            }
+                        function frameLoaded() {
+                            console.log('Sending styles through postMessage');
+                            var styleText = document.getElementsByTagName("html")[0].style.cssText;
+                            document.getElementById('myframe').contentWindow.postMessage(styleText,"http://localhost:${port}/");
+                        }    
+                        function start() {
                             var queryArgs = [
                                 'id=${id}',
                                 'branchName=${encodeURIComponent(branchName)}',
                                 'file=${encodeURIComponent(file)}',
                                 'branchSelection=${branchSelection}',
                                 'locale=${encodeURIComponent(locale)}',
-                                'theme=' + theme,
-                                'styles=' + encodeURIComponent(styles)
+                                'theme=' + document.body.className
                             ];
+                            
                             document.getElementById('myframe').src = 'http://localhost:${internalPort}/?_=${timeNow}&' + queryArgs.join('&');
+                            document.getElementById('myframe').onload = frameLoaded;
                         }
                         </script>
                     </head>

--- a/src/server/contentProvider.ts
+++ b/src/server/contentProvider.ts
@@ -40,16 +40,21 @@ export class ContentProvider implements TextDocumentContentProvider {
                 logger.log(`Server running on ${uri}`);
             });
 
-        return `
-                    <!DOCTYPE html>
-                    <head><style type="text/css"> html, body{ height:100%; width:100%; overflow:hidden; padding:0;margin:0; } </style>
+        return `<!DOCTYPE html>
+                <html>
+                    <head>
+                        <style type="text/css"> html, body{ height:100%; width:100%; overflow:hidden; padding:0;margin:0; }</style>
+                        <meta http-equiv="Content-Security-Policy" content="default-src 'self' http://localhost:${internalPort} http://127.0.0.1:* 'unsafe-inline' 'unsafe-eval';" />
                     <title>Git History</title>
                     <script type="text/javascript">
                         function frameLoaded() {
                             console.log('Sending styles through postMessage');
                             var styleText = document.getElementsByTagName("html")[0].style.cssText;
-                            document.getElementById('myframe').contentWindow.postMessage(styleText,"http://localhost:${port}/");
-                        }    
+                            // since the nested iframe may become the origin http://127.0.0.1:<randomPort>
+                            // it is necessary to use asterisk
+                            document.getElementById('myframe').contentWindow.postMessage(styleText,"*");
+                        }
+
                         function start() {
                             var queryArgs = [
                                 'id=${id}',
@@ -59,14 +64,14 @@ export class ContentProvider implements TextDocumentContentProvider {
                                 'locale=${encodeURIComponent(locale)}',
                                 'theme=' + document.body.className
                             ];
-                            
                             document.getElementById('myframe').src = 'http://localhost:${internalPort}/?_=${timeNow}&' + queryArgs.join('&');
                             document.getElementById('myframe').onload = frameLoaded;
                         }
                         </script>
                     </head>
                     <body onload="start()">
-                    <iframe id="myframe" frameborder="0" style="border: 0px solid transparent;height:100%;width:100%;" src="" seamless></iframe>
-                    </body></html>`;
+                        <iframe id="myframe" frameborder="0" style="border: 0px solid transparent;height:100%;width:100%;" src="" seamless></iframe>
+                    </body>
+                </html>`;
     }
 }

--- a/src/server/contentProvider.ts
+++ b/src/server/contentProvider.ts
@@ -44,7 +44,7 @@ export class ContentProvider implements TextDocumentContentProvider {
                 <html>
                     <head>
                         <style type="text/css"> html, body{ height:100%; width:100%; overflow:hidden; padding:0;margin:0; }</style>
-                        <meta http-equiv="Content-Security-Policy" content="default-src 'self' http://localhost:${internalPort} http://127.0.0.1:* 'unsafe-inline' 'unsafe-eval';" />
+                        <meta http-equiv="Content-Security-Policy" content="default-src 'self' http://localhost:* http://127.0.0.1:* 'unsafe-inline' 'unsafe-eval';" />
                     <title>Git History</title>
                     <script type="text/javascript">
                         function frameLoaded() {

--- a/src/server/serverHost.ts
+++ b/src/server/serverHost.ts
@@ -78,9 +78,7 @@ export class ServerHost extends EventEmitter implements IServerHost {
         });
     }
     public rootRequestHandler(req: Request, res: Response) {
-        // in some cases the hash character is not properly converted
-        // so replace the uri encoded value to #
-        const styles: string = req.query.styles.replace(/%23/g, '#');
+        const styles: string = req.query.styles;
         const theme: string = req.query.theme;
         const themeDetails = this.themeService.getThemeDetails(theme, styles);
         res.render(path.join(__dirname, '..', '..', 'browser', 'index.ejs'), themeDetails);


### PR DESCRIPTION
While passing the styles as argument was working quite good in vscode prior to v1.40 more styles have been added by microsoft (i assume) and the URL length became to long to handle.

As an (almost unlimited) alternative the `contentWindow.postMessage` has been implemented and is listening on file browser/src/index.ejs to "copy" the styles from the parent frame

This also fixes issues related to remote support previously resolved in PR #401 (#379, #389, #388)