### PR TITLE
Get remote url from config remote.[name].url

### DIFF
--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -183,8 +183,8 @@ export class Git implements IGitService {
                 return matchResult && matchResult[1] ? matchResult[1] : 'origin';
             });
 
-            const url = await this.exec('remote', 'get-url', remoteName);
-            return url.substring(0, url.length - 1);
+            const url = await this.exec('config', `remote.${remoteName}.url`);
+            return url.slice(0, url.length - 1);
         } catch {
             return '';
         }


### PR DESCRIPTION
Avoids "fatal: No such remote 'origin'" if remote does not exist (resolves #368)

This change modifies the remote url resolution behavior to use `config remote.remoteName.url` instead of `remote get-url remoteName`.

I created this PR using a docker container for VS Code because I can't install `yarn` on this development machine. In the container environment, when attempting to run/test the extension (following directions at [Contributing > How to run](https://github.com/DonJayamanne/gitHistoryVSCode/blob/c752588c58af016155fad3fece53662eaf4368b5/CONTRIBUTING.md#how-to-run)), I got this error:

```shell
code --extensionDevelopmentPath=.
Ignoring option extensionDevelopmentPath: not supported for code.
At least one file or folder must be provided.
```

So I guess there's some sort of problem loading the VS Code extension host when developing in a container. Due to this error, I was not able to test the change, and will need someone to test it during code review.

The reproduction steps below describe the current behavior that this PR is intending to fix. This change should prevent step 3 from occurring.

1.
    - create test directory
    - cd into directory
    - initiate new git repo
    - create test file
    - stage file
    - commit
    - launch vs code

    In a single terminal command:

    ```shell
    mkdir test \
      && cd test \
      && git init \
      && echo "hello world" > hello_world.txt \
      && git add . \
      && git commit -m "Initial commit" \
      && code .
    ```

2.  (In VS Code) Run in the command palette `Git: View History (git log)`

3. The "Output" panel appears with the following lines at the end:

```shell
git remote get-url origin  (completed in 0.011s)
fatal: No such remote 'origin'
```