### PR TITLE
Browser actions below refs while removing commit-hash-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Version 0.4.14
 - Slightly amended scrollbar and dropdown style to match theme colors [#423](https://github.com/DonJayamanne/gitHistoryVSCode/issues/423)
+- Added browser actionbar for quicker access to relevant functions (E.g. create tag, create branch) [#428](https://github.com/DonJayamanne/gitHistoryVSCode/pull/428)
+- Added modal window to allow user input and confirmation dialogs [#429](https://github.com/DonJayamanne/gitHistoryVSCode/pull/429)
 
 ## Version 0.4.13
 - Applied PR [#420](https://github.com/DonJayamanne/gitHistoryVSCode/pull/420) to fix repositories with no remote, thanks to @jsejcksn

--- a/browser/src/actions/results.ts
+++ b/browser/src/actions/results.ts
@@ -25,11 +25,11 @@ function getQueryUrl(store: RootState, baseUrl: string, args: string[] = []): st
     const queryArgs = args.concat([`id=${encodeURIComponent(id)}`]);
     return `${baseUrl}?${queryArgs.join('&')}`;
 }
-export const actionCommit = (logEntry: LogEntry, name: string = '') => {
+export const actionCommit = (logEntry: LogEntry, name: string = '', value: string = '') => {
     // tslint:disable-next-line:no-any
     return async (dispatch: Dispatch<any>, getState: () => RootState) => {
         const state = getState();
-        const url = getQueryUrl(state, `/action/${name}`);
+        const url = getQueryUrl(state, `/action/${name}`, [`value=${encodeURIComponent(value)}`]);
         return axios.post(url, logEntry);
     };
 };

--- a/browser/src/components/Dialog/index.tsx
+++ b/browser/src/components/Dialog/index.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Button } from 'react-bootstrap';
+
+enum DialogButtons {
+    Ok = 0,
+    OkCancel = 1,
+}
+
+type DialogProps = {
+    onCancel?(): void;
+    onOk?(sender: HTMLButtonElement, args: any): void;
+};
+
+type DialogState = {
+    title: string;
+    description: string;
+    input: boolean;
+    placeholder: string;
+    buttons: DialogButtons;
+    show: boolean;
+    value: string;
+}
+
+/**
+ * A simple dialog component to display a modal window
+ */
+export default class Dialog extends React.Component<DialogProps, DialogState> {
+    private args: any;
+    private inputField: HTMLInputElement;
+    private buttonOk: Button;
+
+    constructor(props: DialogProps) {
+        super(props);
+        this.state = {
+            show: false,
+            value: '',
+            title: '',
+            placeholder: 'Please enter a value here',
+            description: '',
+            input: false,
+            buttons: DialogButtons.OkCancel
+        };
+    }
+
+    /**
+     * handle click event of dialog buttons
+     * @param e the given event
+     */
+    private clickHander(e: Event) {
+        const button: HTMLButtonElement = e.currentTarget as HTMLButtonElement;
+
+        switch (button.name) {
+            case 'cancel':
+                if (this.props.onCancel) {
+                    this.props.onCancel();
+                }
+                break;
+            case 'ok':
+                this.props.onOk(button, this.args);
+                break;
+        }
+
+        this.setState({show: false});
+    }
+
+    /**
+     * create the buttons dependend on the given DialogButtons enum or dialog type (E.g. showInput, showMessage)
+     */
+    private createButtons() {
+        switch (this.state.buttons) {
+            default:
+            case DialogButtons.Ok:
+                return [<Button name='ok' ref={(i) => this.buttonOk = i} bsStyle='primary' onClick={this.clickHander.bind(this)}>Ok</Button>];
+            case DialogButtons.OkCancel:
+                return [
+                    <Button name='cancel' onClick={this.clickHander.bind(this)}>Cancel</Button>,
+                    <Button name='ok' ref={(i) => this.buttonOk = i} style={{'margin-left': '.3em'}} bsStyle='primary' onClick={this.clickHander.bind(this)}>Ok</Button>
+                ];
+        }
+    }
+
+    /**
+     * input change handler triggered on any text change to update field value
+     */
+    private handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ value: e.target.value });
+    }
+
+    /**
+     * KeyDown handler to submit data using 'Enter' key or cancel using 'Escape' key
+     */
+    private handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            const buttonEl = ReactDOM.findDOMNode(this.buttonOk) as HTMLButtonElement;
+            buttonEl.click();
+        } else if (e.key === 'Escape') {
+            this.setState({show: false});
+        }
+    }
+
+    /**
+     * Display a simple message box a user can confirm with DialogButtons.Ok button
+     * 
+     * @param title title of the dialog
+     * @param description description with html entities support
+     * @param args optional arguments
+     */
+    public showMessage(title: string, description: string, args: any = undefined) {
+        this.setState({show: true, title, description});
+        this.args = args;
+    }
+
+    /**
+     * Display an input dialog allow the user to enter text and either submit or cancel using DialogButtons.OkCancel buttons
+     * 
+     * @param title title of the dialog
+     * @param description description with html entities support
+     * @param args optional arguments
+     */
+    public showInput(title: string, description: string, placeholder: string = '', args: any = undefined) {
+        this.setState({show: true, input: true, title, description, placeholder, buttons: DialogButtons.OkCancel}, () => {
+            this.inputField.focus();
+            this.inputField.select();
+        });
+        this.args = args;
+    }
+
+    /**
+     * Fetch the value given in text field
+     */
+    public getValue() {
+        return this.state.value;
+    }
+
+    public render() {
+        return (
+            <div id='dialog' hidden={!this.state.show}>
+                <div>
+                    <div>
+                        <h4>{this.state.title}</h4>
+                        <div dangerouslySetInnerHTML={{__html: this.state.description}}></div>
+                    </div>
+                    <div style={{textAlign: 'center', marginTop: '1em'}}>
+                        <input hidden={!this.state.input} ref={(i) => this.inputField = i} className={'textInput'} type="text" value={this.state.value} onKeyDown={this.handleKeyDown} onChange={this.handleChange} placeholder={this.state.placeholder} />
+                    </div>
+                    <hr />
+                    <div style={{textAlign: 'right'}}>
+                        {this.createButtons()}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/browser/src/components/Header/index.tsx
+++ b/browser/src/components/Header/index.tsx
@@ -64,7 +64,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
         return (<header>
             <input className={'textInput'} type="text" value={this.state.searchText} placeholder="Enter term and press enter to search" onKeyDown={this.handleKeyDown} onChange={this.handleSearchChange} />
             <Button
-                bsStyle='primary' bsSize='small'
+                bsSize='small'
                 disabled={this.state.isLoading}
                 onClick={this.onSearch}>
                 {this.state.isLoading ? 'Loading...' : 'Search'}
@@ -72,11 +72,11 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
             <Branch></Branch>
             <Author></Author>
             <Button
-                bsStyle='warning' bsSize='small'
+                bsSize='small'
                 disabled={this.state.isLoading}
                 onClick={this.onClear}>Clear</Button>
             <Button
-                bsStyle="info" bsSize='small'
+                bsSize='small'
                 disabled={this.state.isLoading}
                 onClick={this.onRefresh}>Refresh</Button>
         </header>);

--- a/browser/src/components/LogView/LogEntry/index.tsx
+++ b/browser/src/components/LogView/LogEntry/index.tsx
@@ -14,8 +14,7 @@ import { GoGitCommit, GoClippy, GoPlus } from 'react-icons/lib/go';
 type ResultListPropsSentToComponent = {
     logEntry: LogEntry;
     onViewCommit(entry: LogEntry): void;
-    onClick(entry: LogEntry): void;
-    onNewClick(entry: LogEntry): void;
+    onAction(entry: LogEntry, name: string): void;
 };
 
 type ResultListProps = ResultListPropsSentToComponent & {
@@ -47,39 +46,35 @@ function LogEntry(props: ResultListProps) {
     return (<div className={cssClassName}>
         <div className='media right'>
             <div className='media-image'>
-                <div className='commit-hash-container'>
-                    <div>
-                        <span className='btnx hint--left hint--rounded hint--bounce' aria-label='New branch or tag'>
-                            <a role='button' onClick={() => props.onNewClick(props.logEntry)}>
-                                <GoPlus></GoPlus>
-                            </a>
-                        </span>
-                    </div>
-                    <CopyToClipboard text={props.logEntry.hash.full}>
-                        <div>
-                            <span className='btnx clipboard hint--left hint--rounded hint--bounce'
-                                aria-label='Copy the full Hash'>
-                                <GoClippy></GoClippy>
-                            </span>
-                        </div>
-                    </CopyToClipboard>
-                    <div>
-                        <span className='btnx hint--left hint--rounded hint--bounce' aria-label='Cherry pick, Compare, etc'>
-                            <a role='button' onClick={() => props.onClick(props.logEntry)}>
-                                <GoGitCommit></GoGitCommit>
-                            </a>
-                        </span>
-                    </div>
-                    <div role='button' onClick={() => props.onViewCommit(props.logEntry)}>
-                        <span className='sha-code short' aria-label={props.logEntry.hash.short}>{props.logEntry.hash.short}</span>
-                    </div>
-                </div>
-            </div>
-            <div className='media-image'>
                 <div className='ref'>
                     {renderRemoteRefs(props.logEntry.refs)}
                     {renderHeadRef(props.logEntry.refs)}
                     {renderTagRef(props.logEntry.refs)}
+                    &nbsp;
+                </div>
+                <div className='buttons'>
+                    <CopyToClipboard text={props.logEntry.hash.full}>
+                    <span className='btnx hash clipboard hint--left hint--rounded hint--bounce' aria-label="Copy hash to clipboard">
+                        {props.logEntry.hash.short}&nbsp;
+                        <GoClippy></GoClippy>
+                    </span>
+                    </CopyToClipboard>
+                    &nbsp;
+                    <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Create a new tag'>
+                        <a role='button' onClick={() => props.onAction(props.logEntry, 'newtag')}>
+                        <GoPlus></GoPlus>Tag
+                        </a>
+                    </span>
+                    <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Create a new branch from here'>
+                        <a role='button' onClick={() => props.onAction(props.logEntry, 'newbranch')}>
+                        <GoPlus></GoPlus>Branch
+                        </a>
+                    </span>
+                    <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Cherry pick, Compare, etc'>
+                        <a role='button' onClick={() => props.onAction(props.logEntry, '')}>
+                            <GoGitCommit></GoGitCommit>More
+                        </a>
+                    </span>
                 </div>
             </div>
             <div role='button' className='media-content' onClick={() => props.onViewCommit(props.logEntry)}>

--- a/browser/src/components/LogView/LogEntry/index.tsx
+++ b/browser/src/components/LogView/LogEntry/index.tsx
@@ -50,31 +50,32 @@ function LogEntry(props: ResultListProps) {
                     {renderRemoteRefs(props.logEntry.refs)}
                     {renderHeadRef(props.logEntry.refs)}
                     {renderTagRef(props.logEntry.refs)}
-                    &nbsp;
                 </div>
                 <div className='buttons'>
-                    <CopyToClipboard text={props.logEntry.hash.full}>
-                    <span className='btnx hash clipboard hint--left hint--rounded hint--bounce' aria-label="Copy hash to clipboard">
-                        {props.logEntry.hash.short}&nbsp;
-                        <GoClippy></GoClippy>
-                    </span>
-                    </CopyToClipboard>
-                    &nbsp;
-                    <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Create a new tag'>
-                        <a role='button' onClick={() => props.onAction(props.logEntry, 'newtag')}>
-                        <GoPlus></GoPlus>Tag
-                        </a>
-                    </span>
-                    <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Create a new branch from here'>
-                        <a role='button' onClick={() => props.onAction(props.logEntry, 'newbranch')}>
-                        <GoPlus></GoPlus>Branch
-                        </a>
-                    </span>
-                    <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Cherry pick, Compare, etc'>
-                        <a role='button' onClick={() => props.onAction(props.logEntry, '')}>
-                            <GoGitCommit></GoGitCommit>More
-                        </a>
-                    </span>
+                    <div>
+                        <CopyToClipboard text={props.logEntry.hash.full}>
+                        <span className='btnx hash clipboard hint--left hint--rounded hint--bounce' aria-label="Copy hash to clipboard">
+                            {props.logEntry.hash.short}&nbsp;
+                            <GoClippy></GoClippy>
+                        </span>
+                        </CopyToClipboard>
+                        &nbsp;
+                        <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Create a new tag'>
+                            <a role='button' onClick={() => props.onAction(props.logEntry, 'newtag')}>
+                            <GoPlus></GoPlus>Tag
+                            </a>
+                        </span>
+                        <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Create a new branch from here'>
+                            <a role='button' onClick={() => props.onAction(props.logEntry, 'newbranch')}>
+                            <GoPlus></GoPlus>Branch
+                            </a>
+                        </span>
+                        <span role='button' className='btnx hint--left hint--rounded hint--bounce' aria-label='Cherry pick, Compare, etc'>
+                            <a role='button' onClick={() => props.onAction(props.logEntry, '')}>
+                                <GoGitCommit></GoGitCommit>More
+                            </a>
+                        </span>
+                    </div>
                 </div>
             </div>
             <div role='button' className='media-content' onClick={() => props.onViewCommit(props.logEntry)}>

--- a/browser/src/components/LogView/LogEntryList/index.tsx
+++ b/browser/src/components/LogView/LogEntryList/index.tsx
@@ -5,8 +5,7 @@ import LogEntryView from '../LogEntry';
 interface ResultProps {
     logEntries: LogEntry[];
     onViewCommit(entry: LogEntry): void;
-    onClick(entry: LogEntry): void;
-    onNewClick(entry: LogEntry): void;
+    onAction(entry: LogEntry, name: string): void;
 }
 
 export default class LogEntryList extends React.Component<ResultProps> {
@@ -30,9 +29,8 @@ export default class LogEntryList extends React.Component<ResultProps> {
                 <LogEntryView
                     key={entry.hash.full}
                     logEntry={entry}
-                    onViewCommit={this.props.onViewCommit}
-                    onNewClick={this.props.onNewClick}
-                    onClick={this.props.onClick} />
+                    onAction={this.props.onAction}
+                    onViewCommit={this.props.onViewCommit} />
         );
         return (
             // tslint:disable-next-line:react-this-binding-issue

--- a/browser/src/components/LogView/LogView/index.tsx
+++ b/browser/src/components/LogView/LogView/index.tsx
@@ -46,8 +46,7 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
             <div className='log-view' id='scrollCnt'>
                 <BranchGraph></BranchGraph>
                 <LogEntryList ref={this.ref} logEntries={this.props.logEntries.items}
-                    onClick={this.onClick}
-                    onNewClick={this.onNewClick}
+                    onAction={this.onAction}
                     onViewCommit={this.onViewCommit}></LogEntryList>
             </div>
         );
@@ -56,11 +55,8 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
     public onViewCommit = (logEntry: LogEntry) => {
         this.props.onViewCommit(logEntry.hash.full);
     }
-    public onClick = (entry: LogEntry) => {
-        this.props.actionCommit(entry);
-    }
-    public onNewClick = (entry: LogEntry) => {
-        this.props.actionCommit(entry, 'new');
+    public onAction = (entry: LogEntry, name: string = '') => { 
+        this.props.actionCommit(entry, name);
     }
 }
 function mapStateToProps(state: RootState, wrapper: { logEntries: LogEntries }) {

--- a/browser/src/containers/App/index.tsx
+++ b/browser/src/containers/App/index.tsx
@@ -46,9 +46,9 @@ class App extends React.Component<AppProps, AppState> {
                         goBack={ this.goBack }
                         goForward={ this.goForward }></Footer>
                     { children }
-                </div >
-                 { this.props.logEntries && this.props.logEntries.selected ? <Commit /> : '' }
-            </div >
+                </div>
+                { this.props.logEntries && this.props.logEntries.selected ? <Commit /> : '' }
+            </div>
         );
     }
     private goBack = async () => {

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -38,13 +38,6 @@ body {
 	pointer-events: none;
 }
 
-.btn_used-by-bootstrap-hence-not-used {
-	cursor: pointer;
-	margin: 0;
-	padding: 0;
-	border-style: none;
-}
-
 .btnx {
 	cursor: pointer;
 	margin: 0;
@@ -172,6 +165,10 @@ div.appRoot {
 
 .log-entry .media-image > div.buttons .hash {
 	opacity: 0.7;
+}
+
+.log-entry .media-image > div.buttons a {
+	color: var(--vscode-textLink-foreground);
 }
 
 .log-entry .media-image > div.buttons a:hover {
@@ -624,42 +621,26 @@ a.file-name {
 
 .btn {
     color: var(--vscode-input-foreground);
-    background: var(--vscode-input-background);
-    border: 1px solid var(--vscode-input-background);
-    border-radius: 0;
-}
-
-.btn:focus {
-    border: var(--vscode-focusBorder);
+	background: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-background);
+	border-radius: 0;
 }
 
 .btn-group-sm>.btn, .btn-sm {
     border-radius: 0;
 }
 
-.btn:hover {
+.btn:hover, btn:focus {
     color: var(--vscode-breadcrumb-focusForeground);
     background: var(--vscode-input-background);
     border: 1px solid var(--vscode-focusBorder);
 }
 
-.btn-warning:hover {
-    background: var(--vscode-input-background);
-    border: 1px solid var(--vscode-inputValidation-warningBorder);
-}
-
-.btn-info:hover {
-    background: var(--vscode-input-background);
-    border: 1px solid var(--vscode-inputValidation-infoBorder);
-}
-
 .textInput {
     position: relative;
-    top: 1px;
-    left: 2px;
     font-size: 12px;
-    line-height: 1.5;
 	padding: 5px 10px;
+	vertical-align: top;
 	width: 250px;
     color: var(--vscode-input-foreground);
     background: var(--vscode-input-background);

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -389,31 +389,30 @@ header input, header button {
 }
 
 
-/* Errors */
-
-.error-box {
-	text-align: center;
-	color: #c33;
-	padding: 3rem;
+/* Dialog Modal */
+#dialog {
+	position: fixed;
+	top: 0px;
+	width: 100%;
+	height: 100%;
+	background-color: var(--vscode-scrollbarSlider-background);
+	z-index: 99999;
 }
 
-.error-box {
-	animation-duration: 0.75s;
+#dialog hr {
+	border-top: 1px solid var(--vscode-editorGroup-border);
 }
 
-.error-box .error-icon>i {
-	font-size: 4em;
-	margin-right: 0;
+#dialog > div {
+	padding: 1em;
+	border: 2px solid var(--vscode-editorGroup-border);
+	background-color: var(--vscode-editor-background);
+	width: 50%;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 }
-
-.error-box .error-title {
-	font-weight: lighter;
-}
-
-.error-box .error-details {
-	font-weight: normal;
-}
-
 
 /* Details View */
 .hidden {

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -64,7 +64,7 @@ body {
 }
 
 .media.right .media-image {
-	margin: 0.8em 0.5em 0 0;
+	margin: 0.8em 0.3em 0 0;
 }
 
 div.appRootParent {
@@ -78,7 +78,6 @@ div.appRoot {
 	overflow: hidden;
 }
 
-#log-view,
 .log-view {
 	position: relative;
 	overflow-y: scroll;
@@ -86,42 +85,28 @@ div.appRoot {
 	height: 100vh;
 }
 
-.log-entry {
-	border-bottom-width: 1px;
-	border-bottom-style: solid;
-	border-bottom-color: var(--vscode-editorGroup-border);
-}
-  
-#log-view.with-details {
-	height: calc(100% - 20rem);
-}
-
-#log-view.with-details.with-details-resized {
-	height: 20rem;
-}
-
-#log-view svg.commitGraph,
 .log-view svg.commitGraph {
 	position: absolute;
 	top: 0;
 	left: 0;
 }
 
-#log-view svg.commitGraph,
 .log-view svg.commitGraph path {
 	stroke-width: 3;
 	fill: none;
 }
 
-#log-view svg.commitGraph,
 .log-view svg.commitGraph circle {
 	stroke: white;
 	stroke-width: 0.1em;
 	fill: #333;
 }
 
-#commit-history {
-	padding: 0;
+
+.log-entry {
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
+	border-bottom-color: var(--vscode-editorGroup-border);
 }
 
 .log-entry {
@@ -144,27 +129,33 @@ div.appRoot {
 
 .log-entry .media-image > div.ref {
 	min-width: 1em;
+	height: 20px;
 	display: flex;
 	flex-wrap: nowrap;
 	justify-content: flex-end;
 }
 
 .log-entry .media-image > div.buttons {
-	margin-top: .3em;
-	margin-bottom: .3em;
-	min-width: 1em;
+	margin-top: .5em;
+	margin-bottom: 0px;
 	display: flex;
 	justify-content: flex-end;
-	font-size: 75%;
-	font-weight: normal;
 }
 
-.log-entry .media-image > div.buttons > .btnx {
+.log-entry .media-image > div.buttons > div {
+	background-color: var(--vscode-activityBar-background);
+	padding: .3em .5em .3em 0em;
+	font-size: 75%;
+	font-weight: normal;
+	text-align: right;
+}
+
+.log-entry .media-image > div.buttons .btnx {
 	margin-left: .5em;
 }
 
 .log-entry .media-image > div.buttons .hash {
-	opacity: 0.7;
+	font-family: monospace;
 }
 
 .log-entry .media-image > div.buttons a {
@@ -175,22 +166,7 @@ div.appRoot {
 	text-decoration: none;
 }
 
-.log-entry a.commit-subject-link {
-	display: block;
-	height: 1em;
-	position: absolute;
-	width: 100%;
-	color: transparent !important;
-}
-
-.log-entry .commit-subject-link:hover~.commit-subject,
-.log-entry .commit-subject-link~.commit-subject:hover {
-	text-decoration: underline;
-	cursor: pointer;
-}
-
 .log-entry .commit-subject {
-	font-weight: bold;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -201,10 +177,6 @@ div.appRoot {
     width:15px;
     float:left;
     margin:0.2em 0.4em 0em 0em;
-}
-
-.commit-subject {
-	font-weight: bold;
 }
 
 .commit-author {
@@ -226,11 +198,11 @@ div.appRoot {
 .commit-head-container {
 	border-radius: 5px;
 	margin-left: .3em;
+	white-space: nowrap;
 }
 
 .commit-head-container {
 	background-color: var(--vscode-editorGutter-addedBackground);
-	white-space: nowrap;
 }
 
 .commit-remote-container {
@@ -280,40 +252,7 @@ div.appRoot {
 	background-color: hsla(0, 0%, 100%, 0.12);
 }
 
-.copy-button .clipboard {
-	opacity: 0.8;
-}
-
-.copy-button .clipboard:hover {
-	opacity: 1;
-}
-
-.copy-button .clipboard-link {
-	position: absolute;
-	left: 0;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	opacity: 0;
-}
-
-.sha-code {
-	font-family: Consolas, 'Courier New', monospace;
-}
-
-.sha-code.short {
-	width: 7em;
-}
-
-.log-entry.active .commit-hash-container {
-	background-color: var(--vscode-inputValidation-infoBackground);
-}
-
-.log-entry.active .commit-subject {
-	color: var(--vscode-textLink-foreground);
-}
-
-.log-entry.active .commit-author {
+.log-entry.active .commit-subject, .log-entry.active .commit-author {
 	color: var(--vscode-textLink-foreground);
 }
 
@@ -324,7 +263,6 @@ header {
 header input, header button {
     margin: 0.2em;
 }
-
 
 /* Navigation*/
 
@@ -388,7 +326,6 @@ header input, header button {
 	color: hsla(0, 0%, 100%, 0.5);
 }
 
-
 /* Dialog Modal */
 #dialog {
 	position: fixed;
@@ -417,19 +354,6 @@ header input, header button {
 /* Details View */
 .hidden {
 	display:none;
-}
-
-div.commitCntDrag {
-	width: 100vw !important;
-	display: block !important;
-	height: 200px;
-}
-
-div.react-draggable.react-draggable-dragged,
-div.react-draggable {
-	width: 100% !important;
-	bottom: 45px !important;
-	position: absolute;
 }
 
 div.details-view-cnt {

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -145,11 +145,14 @@ div.appRoot {
 
 .log-entry .media-image {
 	min-width: 6em;
+	display: flex;
+	flex-direction: column;
 }
 
 .log-entry .media-image > div.ref {
 	min-width: 1em;
 	display: flex;
+	flex-wrap: nowrap;
 	justify-content: flex-end;
 }
 
@@ -160,6 +163,19 @@ div.appRoot {
 	display: flex;
 	justify-content: flex-end;
 	font-size: 75%;
+	font-weight: normal;
+}
+
+.log-entry .media-image > div.buttons > .btnx {
+	margin-left: .5em;
+}
+
+.log-entry .media-image > div.buttons .hash {
+	opacity: 0.7;
+}
+
+.log-entry .media-image > div.buttons a:hover {
+	text-decoration: none;
 }
 
 .log-entry a.commit-subject-link {
@@ -206,12 +222,6 @@ div.appRoot {
 
 .commit-author .timestamp {
 	opacity: 0.7;
-}
-
-.commit-hash-container {
-    background-color: var(--vscode-inputValidation-infoBackground);
-    color: var(--vscode-input-foreground);
-    white-space: nowrap;
 }
 
 .commit-remote-container,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "githistory",
-  "version": "0.4.11",
+  "version": "0.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "githistory",
     "displayName": "Git History",
     "description": "View git log, file history, compare branches or commits",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "publisher": "donjayamanne",
     "author": {
         "name": "Don Jayamanne",

--- a/src/server/apiController.ts
+++ b/src/server/apiController.ts
@@ -239,20 +239,21 @@ export class ApiController implements IApiRouteHandler {
         const workspaceFolder = this.getWorkspace(id);
         const currentState = this.stateStore.getState(id)!;
         const actionName = request.param('name');
+        const value = decodeURIComponent(request.query.value);
         const logEntry = request.body as LogEntry;
-        
-        switch(actionName) {
-            default: 
+
+        switch (actionName) {
+            default:
                 this.commandManager.executeCommand('git.commit.doSomething', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
                 break;
             case 'new':
                 this.commandManager.executeCommand('git.commit.doNewRef', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
                 break;
             case 'newtag':
-                this.commandManager.executeCommand('git.commit.createTag', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
+                this.commandManager.executeCommand('git.commit.createTag', new CommitDetails(workspaceFolder, currentState.branch!, logEntry), value);
                 break;
             case 'newbranch':
-                this.commandManager.executeCommand('git.commit.createBranch', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
+                this.commandManager.executeCommand('git.commit.createBranch', new CommitDetails(workspaceFolder, currentState.branch!, logEntry), value);
                 break;
         }
     }


### PR DESCRIPTION
This PR focused a bit on the usability when single actions, like "create tag" are necessary to be displayed and called upfront.

To achieve it I have removed the commit hash container on the right side and replaced it with an  "actionbar" below the refs. See screenshot below

**Old**

![image](https://user-images.githubusercontent.com/4850116/73133218-e0573280-4025-11ea-96ba-1575e023abf8.png)

**New**
*Updated*
![image](https://user-images.githubusercontent.com/4850116/73463491-9fd91b00-437d-11ea-8a22-a6e46d4e234b.png)


@DonJayamanne Do you agree to this change?
