### PR TITLE
Browser action dialog

### DIFF
--- a/browser/src/actions/results.ts
+++ b/browser/src/actions/results.ts
@@ -25,11 +25,11 @@ function getQueryUrl(store: RootState, baseUrl: string, args: string[] = []): st
     const queryArgs = args.concat([`id=${encodeURIComponent(id)}`]);
     return `${baseUrl}?${queryArgs.join('&')}`;
 }
-export const actionCommit = (logEntry: LogEntry, name: string = '') => {
+export const actionCommit = (logEntry: LogEntry, name: string = '', value: string = '') => {
     // tslint:disable-next-line:no-any
     return async (dispatch: Dispatch<any>, getState: () => RootState) => {
         const state = getState();
-        const url = getQueryUrl(state, `/action/${name}`);
+        const url = getQueryUrl(state, `/action/${name}`, [`value=${encodeURIComponent(value)}`]);
         return axios.post(url, logEntry);
     };
 };

--- a/browser/src/components/Dialog/index.tsx
+++ b/browser/src/components/Dialog/index.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { Button } from 'react-bootstrap';
+
+enum DialogButtons {
+    Ok = 0,
+    OkCancel = 1,
+}
+
+type DialogProps = {
+    onCancel?(): void;
+    onOk?(sender: HTMLButtonElement, args: any): void;
+};
+
+type DialogState = {
+    title: string;
+    description: string;
+    input: boolean;
+    buttons: DialogButtons;
+    show: boolean;
+    value: string;
+}
+export default class Dialog extends React.Component<DialogProps, DialogState> {
+    private args: any;
+    private inputField: HTMLInputElement;
+    constructor(props: DialogProps) {
+        super(props);
+        this.state = {
+            show: false,
+            value: '',
+            title: '',
+            description: '',
+            input: false,
+            buttons: DialogButtons.OkCancel
+        };
+    }
+
+    private clickHander(e: Event) {
+        const button: HTMLButtonElement = e.currentTarget as HTMLButtonElement;
+
+        switch (button.name) {
+            case 'cancel':
+                if (this.props.onCancel) {
+                    this.props.onCancel();
+                }
+                break;
+            case 'ok':
+                this.props.onOk(button, this.args);
+                break;
+        }
+
+        this.setState({show: false});
+    }
+
+    private createButtons() {
+        switch (this.state.buttons) {
+            default:
+            case DialogButtons.Ok:
+                return [<Button name='ok' bsStyle='primary' onClick={this.clickHander.bind(this)}>Ok</Button>];
+            case DialogButtons.OkCancel:
+                return [
+                    <Button name='cancel' onClick={this.clickHander.bind(this)}>Cancel</Button>,
+                    <Button name='ok' style={{'margin-left': '.3em'}} bsStyle='primary' onClick={this.clickHander.bind(this)}>Ok</Button>
+                ];
+        }
+    }
+
+    private handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ value: e.target.value });
+    }
+
+    public showMessage(title: string, description: string, args: any = undefined) {
+        this.setState({show: true, title, description});
+        this.args = args;
+    }
+
+    public showInput(title: string, description: string, args: any = undefined) {
+        this.setState({show: true, input: true, title, description, buttons: DialogButtons.OkCancel}, () => {
+            this.inputField.focus();
+            this.inputField.select();
+        });
+        this.args = args;
+    }
+
+    public getValue() {
+        return this.state.value;
+    }
+
+    public render() {
+        return (
+            <div id='dialog' hidden={!this.state.show}>
+                <div>
+                    <div>
+                        <h4>{this.state.title}</h4>
+                        <div dangerouslySetInnerHTML={{__html: this.state.description}}></div>
+                    </div>
+                    <div style={{textAlign: 'center', marginTop: '1em'}}>
+                        <input hidden={!this.state.input} ref={(i) => this.inputField = i} className={'textInput'} type="text" value={this.state.value} onChange={this.handleChange} placeholder="Enter value" />
+                    </div>
+                    <hr />
+                    <div style={{textAlign: 'right'}}>
+                        {this.createButtons()}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/browser/src/components/LogView/LogView/index.tsx
+++ b/browser/src/components/LogView/LogView/index.tsx
@@ -13,6 +13,7 @@ type LogViewProps = {
     onViewCommit: typeof ResultActions.selectCommit;
     actionCommit: typeof ResultActions.actionCommit;
     refresh: typeof ResultActions.refresh;
+    selectBranch: typeof ResultActions.selectBranch;
 };
 
 // tslint:disable-next-line:no-empty-interface
@@ -63,12 +64,12 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
     }
 
     public onAction = (entry: LogEntry, name: string = '') => {
-        switch(name) {
+        switch (name) {
             case 'newtag':
-                this.dialog.showInput("Add tag on " + entry.hash.short, '<strong>' + entry.subject + '</strong><br />' + entry.author.name + ' on ' + entry.author.date.toISOString(), {entry, name});
+                this.dialog.showInput("Create a new tag on " + entry.hash.short, '<strong>' + entry.subject + '</strong><br />' + entry.author.name + ' on ' + entry.author.date.toISOString(), 'Enter tag here', {entry, name});
                 break;
             case 'newbranch':
-                this.dialog.showInput("Branch from " + entry.hash.short, '<strong>' + entry.subject + '</strong><br />' + entry.author.name + ' on ' + entry.author.date.toISOString(), {entry, name});
+                this.dialog.showInput("Create a branch from " + entry.hash.short, '<strong>' + entry.subject + '</strong><br />' + entry.author.name + ' on ' + entry.author.date.toISOString(), 'Enter branch name here', {entry, name});
                 break;
             default:
                 this.props.actionCommit(entry, name);
@@ -78,7 +79,15 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
 
     public onActionCommit = (sender: HTMLButtonElement, args: any) => {
         this.props.actionCommit(args.entry, args.name, this.dialog.getValue());
-        this.props.refresh();
+
+        switch (args.name) {
+            case 'newtag':
+                this.props.refresh();
+                break;
+            case 'newbranch':
+                this.props.selectBranch(this.dialog.getValue());
+                break;
+        }
     }
 }
 function mapStateToProps(state: RootState, wrapper: { logEntries: LogEntries }) {
@@ -92,7 +101,8 @@ function mapDispatchToProps(dispatch) {
         commitsRendered: (height: number) => dispatch(ResultActions.commitsRendered(height)),
         onViewCommit: (hash: string) => dispatch(ResultActions.selectCommit(hash)),
         actionCommit: (logEntry: LogEntry, name: string, value: string = '') => dispatch(ResultActions.actionCommit(logEntry, name, value)),
-        refresh: () => dispatch(ResultActions.refresh())
+        refresh: () => dispatch(ResultActions.refresh()),
+        selectBranch: (branchName: string) => dispatch(ResultActions.selectBranch(branchName)),
     };
 }
 

--- a/browser/src/components/LogView/LogView/index.tsx
+++ b/browser/src/components/LogView/LogView/index.tsx
@@ -5,12 +5,14 @@ import { LogEntries, LogEntry } from '../../../definitions';
 import { RootState } from '../../../reducers';
 import BranchGraph from '../BranchGraph';
 import LogEntryList from '../LogEntryList';
+import Dialog from '../../Dialog';
 
 type LogViewProps = {
     logEntries: LogEntries;
     commitsRendered: typeof ResultActions.commitsRendered;
     onViewCommit: typeof ResultActions.selectCommit;
     actionCommit: typeof ResultActions.actionCommit;
+    refresh: typeof ResultActions.refresh;
 };
 
 // tslint:disable-next-line:no-empty-interface
@@ -18,13 +20,15 @@ interface LogViewState {
 }
 
 class LogView extends React.Component<LogViewProps, LogViewState> {
+    private ref: React.RefObject<LogEntryList>;
+    private dialog: Dialog;
     // tslint:disable-next-line:no-any
     constructor(props?: LogViewProps, context?: any) {
         super(props, context);
         // this.state = { height: '', width: '', itemHeight: 0 };
         this.ref = React.createRef<LogEntryList>();
     }
-    private ref: React.RefObject<LogEntryList>;
+    
     public componentDidUpdate() {
         const el = this.ref.current.ref;
 
@@ -47,7 +51,9 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
                 <BranchGraph></BranchGraph>
                 <LogEntryList ref={this.ref} logEntries={this.props.logEntries.items}
                     onAction={this.onAction}
-                    onViewCommit={this.onViewCommit}></LogEntryList>
+                    onViewCommit={this.onViewCommit}>
+                </LogEntryList>
+                <Dialog ref={(r) => this.dialog = r} onOk={this.onActionCommit.bind(this)} />
             </div>
         );
     }
@@ -55,8 +61,24 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
     public onViewCommit = (logEntry: LogEntry) => {
         this.props.onViewCommit(logEntry.hash.full);
     }
-    public onAction = (entry: LogEntry, name: string = '') => { 
-        this.props.actionCommit(entry, name);
+
+    public onAction = (entry: LogEntry, name: string = '') => {
+        switch(name) {
+            case 'newtag':
+                this.dialog.showInput("Add tag on " + entry.hash.short, '<strong>' + entry.subject + '</strong><br />' + entry.author.name + ' on ' + entry.author.date.toISOString(), {entry, name});
+                break;
+            case 'newbranch':
+                this.dialog.showInput("Branch from " + entry.hash.short, '<strong>' + entry.subject + '</strong><br />' + entry.author.name + ' on ' + entry.author.date.toISOString(), {entry, name});
+                break;
+            default:
+                this.props.actionCommit(entry, name);
+                break;
+        }
+    }
+
+    public onActionCommit = (sender: HTMLButtonElement, args: any) => {
+        this.props.actionCommit(args.entry, args.name, this.dialog.getValue());
+        this.props.refresh();
     }
 }
 function mapStateToProps(state: RootState, wrapper: { logEntries: LogEntries }) {
@@ -69,7 +91,8 @@ function mapDispatchToProps(dispatch) {
     return {
         commitsRendered: (height: number) => dispatch(ResultActions.commitsRendered(height)),
         onViewCommit: (hash: string) => dispatch(ResultActions.selectCommit(hash)),
-        actionCommit: (logEntry: LogEntry, name: string) => dispatch(ResultActions.actionCommit(logEntry, name))
+        actionCommit: (logEntry: LogEntry, name: string, value: string = '') => dispatch(ResultActions.actionCommit(logEntry, name, value)),
+        refresh: () => dispatch(ResultActions.refresh())
     };
 }
 

--- a/browser/src/containers/App/index.tsx
+++ b/browser/src/containers/App/index.tsx
@@ -46,9 +46,9 @@ class App extends React.Component<AppProps, AppState> {
                         goBack={ this.goBack }
                         goForward={ this.goForward }></Footer>
                     { children }
-                </div >
-                 { this.props.logEntries && this.props.logEntries.selected ? <Commit /> : '' }
-            </div >
+                </div>
+                { this.props.logEntries && this.props.logEntries.selected ? <Commit /> : '' }
+            </div>
         );
     }
     private goBack = async () => {

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -389,7 +389,29 @@ header input, header button {
 }
 
 
-/* Errors */
+/* Dialog Modal */
+#dialog {
+	position: fixed;
+	top: 0px;
+	width: 100%;
+	height: 100%;
+	background-color: var(--vscode-scrollbarSlider-background);
+}
+
+#dialog hr {
+	border-top: 1px solid var(--vscode-editorGroup-border);
+}
+
+#dialog > div {
+	padding: 1em;
+	border: 2px solid var(--vscode-editorGroup-border);
+	background-color: var(--vscode-editor-background);
+	width: 50%;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+}
 
 .error-box {
 	text-align: center;

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -396,6 +396,7 @@ header input, header button {
 	width: 100%;
 	height: 100%;
 	background-color: var(--vscode-scrollbarSlider-background);
+	z-index: 99999;
 }
 
 #dialog hr {
@@ -412,30 +413,6 @@ header input, header button {
 	left: 50%;
 	transform: translate(-50%, -50%);
 }
-
-.error-box {
-	text-align: center;
-	color: #c33;
-	padding: 3rem;
-}
-
-.error-box {
-	animation-duration: 0.75s;
-}
-
-.error-box .error-icon>i {
-	font-size: 4em;
-	margin-right: 0;
-}
-
-.error-box .error-title {
-	font-weight: lighter;
-}
-
-.error-box .error-details {
-	font-weight: normal;
-}
-
 
 /* Details View */
 .hidden {

--- a/src/server/apiController.ts
+++ b/src/server/apiController.ts
@@ -239,20 +239,21 @@ export class ApiController implements IApiRouteHandler {
         const workspaceFolder = this.getWorkspace(id);
         const currentState = this.stateStore.getState(id)!;
         const actionName = request.param('name');
+        const value = decodeURIComponent(request.query.value);
         const logEntry = request.body as LogEntry;
-        
-        switch(actionName) {
-            default: 
+
+        switch (actionName) {
+            default:
                 this.commandManager.executeCommand('git.commit.doSomething', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
                 break;
             case 'new':
                 this.commandManager.executeCommand('git.commit.doNewRef', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
                 break;
             case 'newtag':
-                this.commandManager.executeCommand('git.commit.createTag', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
+                this.commandManager.executeCommand('git.commit.createTag', new CommitDetails(workspaceFolder, currentState.branch!, logEntry), value);
                 break;
             case 'newbranch':
-                this.commandManager.executeCommand('git.commit.createBranch', new CommitDetails(workspaceFolder, currentState.branch!, logEntry));
+                this.commandManager.executeCommand('git.commit.createBranch', new CommitDetails(workspaceFolder, currentState.branch!, logEntry), value);
                 break;
         }
     }


### PR DESCRIPTION
While changing the browser with an "actionbar" (see PR #428) I noted it may be useful to have a dialog allowing the user to enter information before submitting, followed by a refresh of the commits

Also this dialog can be used to prompt for confirmation for future actions (like git reset --hard). So that the user is warned

This is how it currently looks like:

![git-history-browser-dialog](https://user-images.githubusercontent.com/4850116/73350504-717c1280-428d-11ea-8b9e-1734c9274c24.gif)

