### PR TITLE
Replace git command with git extension api (2/2)

### DIFF
--- a/src/adapter/parsers/log/parser.ts
+++ b/src/adapter/parsers/log/parser.ts
@@ -10,14 +10,7 @@ export class LogParser implements ILogParser {
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
         @inject(IActionDetailsParser) private actionDetailsParser: IActionDetailsParser,
     ) {}
-    public parse(
-        gitRepoPath: string,
-        summaryEntry: string,
-        itemEntrySeparator: string,
-        logFormatArgs: string[],
-        filesWithNumStat?: string,
-        filesWithNameStatus?: string,
-    ): LogEntry {
+    public parse(summaryEntry: string, itemEntrySeparator: string, logFormatArgs: string[]): LogEntry {
         const logItems = summaryEntry.split(itemEntrySeparator);
 
         const fullParentHash = this.getCommitInfo(logItems, logFormatArgs, CommitInfo.ParentFullHash)
@@ -29,7 +22,6 @@ export class LogParser implements ILogParser {
         const parents = fullParentHash.map((hash, index) => {
             return { full: hash, short: shortParentHash[index] };
         });
-        const committedFiles = this.parserCommittedFiles(gitRepoPath, filesWithNumStat, filesWithNameStatus);
 
         return {
             refs: [],
@@ -38,7 +30,6 @@ export class LogParser implements ILogParser {
             body: this.getCommitInfo(logItems, logFormatArgs, CommitInfo.Body),
             notes: this.getCommitInfo(logItems, logFormatArgs, CommitInfo.Notes),
             parents,
-            committedFiles,
             hash: {
                 full: this.getCommitInfo(logItems, logFormatArgs, CommitInfo.FullHash),
                 short: this.getCommitInfo(logItems, logFormatArgs, CommitInfo.ShortHash),
@@ -50,7 +41,8 @@ export class LogParser implements ILogParser {
             subject: this.getCommitInfo(logItems, logFormatArgs, CommitInfo.Subject),
         };
     }
-    private parserCommittedFiles(
+
+    public parserCommittedFiles(
         gitRepoPath: string,
         filesWithNumStat?: string,
         filesWithNameStatus?: string,
@@ -70,6 +62,7 @@ export class LogParser implements ILogParser {
             return [];
         }
     }
+
     private getCommitInfo(logItems: string[], logFormatArgs: string[], info: CommitInfo): string {
         const commitInfoFormatCode = Helpers.GetCommitInfoFormatCode(info);
         const indexInArgs = logFormatArgs.indexOf(commitInfoFormatCode);

--- a/src/adapter/parsers/types.ts
+++ b/src/adapter/parsers/types.ts
@@ -17,12 +17,6 @@ export interface IActionDetailsParser {
 }
 export const ILogParser = Symbol.for('ILogParser');
 export interface ILogParser {
-    parse(
-        gitRepoPath: string,
-        summaryEntry: string,
-        itemEntrySeparator: string,
-        logFormatArgs: string[],
-        filesWithNumStat?: string,
-        filesWithNameStatus?: string,
-    ): LogEntry;
+    parse(summaryEntry: string, itemEntrySeparator: string, logFormatArgs: string[]): LogEntry;
+    parserCommittedFiles(gitRepoPath: string, filesWithNumStat?: string, filesWithNameStatus?: string): CommittedFile[];
 }

--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -228,7 +228,6 @@ export class Git implements IGitService {
             author,
         );
 
-        const gitRepoPath = this.getGitRoot();
         const countPromise = lineNumber
             ? Promise.resolve(-1)
             : this.exec(...args.counterArgs).then(value => parseInt(value));
@@ -242,7 +241,7 @@ export class Git implements IGitService {
                 if (entry.length === 0) {
                     return;
                 }
-                return this.logParser.parse(gitRepoPath, entry, ITEM_ENTRY_SEPARATOR, LOG_FORMAT_ARGS);
+                return this.logParser.parse(entry, ITEM_ENTRY_SEPARATOR, LOG_FORMAT_ARGS);
             })
             .filter(logEntry => logEntry !== undefined)
             .map(logEntry => {
@@ -275,43 +274,47 @@ export class Git implements IGitService {
 
     @captureTelemetry()
     public async getCommit(hash: string, withRefs = false): Promise<LogEntry | undefined> {
-        const commitArgs = this.gitArgsService.getCommitArgs(hash);
+        const commitMessage = await this.repo.getCommit(hash);
+
+        const numStatusArgs = this.gitArgsService.getCommitWithNumStatArgsForMerge(hash);
         const nameStatusArgs = this.gitArgsService.getCommitNameStatusArgsForMerge(hash);
 
         const gitRootPath = this.getGitRoot();
-        const commitOutput = await this.exec(...commitArgs);
+        const [filesWithNumStatus, filesWithNameStatus] = await Promise.all([
+            this.exec(...numStatusArgs),
+            this.exec(...nameStatusArgs),
+        ]);
 
-        const filesWithNumStat = commitOutput.slice(
-            commitOutput.lastIndexOf(ITEM_ENTRY_SEPARATOR) + ITEM_ENTRY_SEPARATOR.length,
+        const committedFiles = this.logParser.parserCommittedFiles(
+            gitRootPath,
+            filesWithNumStatus,
+            filesWithNameStatus,
         );
-        const filesWithNameStatus = await this.exec(...nameStatusArgs);
 
-        const entries = commitOutput
-            .split(LOG_ENTRY_SEPARATOR)
-            .map(entry => {
-                if (entry.trim().length === 0) {
-                    return undefined;
-                }
-                return this.logParser.parse(
-                    gitRootPath,
-                    entry,
-                    ITEM_ENTRY_SEPARATOR,
-                    LOG_FORMAT_ARGS,
-                    filesWithNumStat,
-                    filesWithNameStatus,
-                );
-            })
-            .filter(entry => entry !== undefined)
-            .map(entry => entry!);
+        const lineBreakIndex = commitMessage.message.indexOf('\n');
+        let title = commitMessage.message;
 
-        if (entries.length > 0) {
-            if (withRefs) {
-                entries[0].refs = this.getRefsContainingCommit(hash);
-            }
-            return entries[0];
+        if (lineBreakIndex > 0) {
+            title = title.substr(0, lineBreakIndex);
         }
 
-        return undefined;
+        return {
+            author: {
+                name: commitMessage.authorName,
+                email: commitMessage.authorEmail,
+                date: commitMessage.authorDate,
+            },
+            parents: commitMessage.parents.map<Hash>(x => {
+                return { full: x, short: x.substr(0, 8) };
+            }),
+            hash: { full: commitMessage.hash, short: commitMessage.hash.substr(0, 8) } as Hash,
+            tree: { full: commitMessage.hash, short: commitMessage.hash.substr(0, 8) } as Hash,
+            refs: withRefs ? this.getRefsContainingCommit(hash) : [],
+            subject: title,
+            notes: '',
+            body: lineBreakIndex > 0 ? commitMessage.message.substr(lineBreakIndex + 1).trimLeft() : '',
+            committedFiles: committedFiles,
+        } as LogEntry;
     }
 
     @cache('IGitService')

--- a/src/adapter/repository/gitArgsService.ts
+++ b/src/adapter/repository/gitArgsService.ts
@@ -6,9 +6,6 @@ import { GitLogArgs, IGitArgsService } from './types';
 
 @injectable()
 export class GitArgsService implements IGitArgsService {
-    public getCommitArgs(hash: string): string[] {
-        return ['show', LOG_FORMAT, '--decorate=full', '--numstat', hash];
-    }
     public getCommitParentHashesArgs(hash: string): string[] {
         return ['log', '--format=%p', '-n1', hash];
     }

--- a/src/adapter/repository/types.ts
+++ b/src/adapter/repository/types.ts
@@ -9,7 +9,6 @@ export const IGitArgsService = Symbol.for('IGitArgsService');
 
 export interface IGitArgsService {
     getAuthorsArgs(): string[];
-    getCommitArgs(hash: string): string[];
     getCommitParentHashesArgs(hash: string): string[];
     getCommitWithNumStatArgs(hash: string): string[];
     getCommitNameStatusArgs(hash: string): string[];


### PR DESCRIPTION
This PR is the second part containing of using native git api provided by vscode.
First part can be found in PR #410

The following methods are still executed from command line (pending)

* getDifferences

The following methods are still executed from command line

* getAuthors
* getCommit - [vscode issue #88294](https://github.com/microsoft/vscode/issues/88294)
* getCommitFile
* getLogEntries - [vscode issue #86008](https://github.com/microsoft/vscode/issues/86008)
