### PR TITLE
fixed references not updating and disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixed deprecated react methods [#480](https://github.com/DonJayamanne/gitHistoryVSCode/pull/480)
 - Applied PR [#483](https://github.com/DonJayamanne/gitHistoryVSCode/pull/483)
 - Added PR validator using Github actions [#481](https://github.com/DonJayamanne/gitHistoryVSCode/pull/481)
+- Fixed references not updating and disappearing [#484](https://github.com/DonJayamanne/gitHistoryVSCode/pull/484)
 
 ## Version 0.6.1
 - Fixed [#478](https://github.com/DonJayamanne/gitHistoryVSCode/issues/478)

--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -10,12 +10,13 @@ import { ActionedUser, Branch, CommittedFile, Hash, IGitService, LogEntries, Log
 import { IGitCommandExecutor } from '../exec';
 import { IFileStatParser, ILogParser } from '../parsers/types';
 import { ITEM_ENTRY_SEPARATOR, LOG_ENTRY_SEPARATOR, LOG_FORMAT_ARGS } from './constants';
-import { Repository } from './git.d';
+import { Repository, RefType } from './git.d';
 import { GitOriginType } from './index';
 import { IGitArgsService } from './types';
 
 @injectable()
 export class Git implements IGitService {
+    private refHashesMap: Map<string, string> = new Map<string, string>();
     constructor(
         private repo: Repository,
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
@@ -143,9 +144,38 @@ export class Git implements IGitService {
 
         return '';
     }
-    public async getRefsContainingCommit(hash: string): Promise<string[]> {
-        return this.repo.state.refs.filter(x => x.commit === hash).map(x => x.name || '');
+
+    /**
+     * Used to load dereferenced hashes for (annotation) tags
+     */
+    private async loadDereferenceHashes() {
+        this.refHashesMap.clear();
+
+        const tags = this.repo.state.refs.filter(x => x.type === RefType.Tag);
+        const tagNames = tags.map(x => {
+            // use the dereferenced hash for annotated tags
+            // this also works for non annotated tags
+            return x.name! + '^{}';
+        });
+
+        const result = await this.exec(...['rev-parse', ...tagNames]);
+
+        result
+            .trim()
+            .split(/\r\n|\n/)
+            .forEach((x, i) => {
+                this.refHashesMap.set(tags[i].name!, x);
+            });
     }
+
+    public getRefsContainingCommit(hash: string): Ref[] {
+        return this.repo.state.refs
+            .filter(x => (x.type === RefType.Tag && this.refHashesMap.get(x.name!) === hash) || x.commit === hash)
+            .map(x => {
+                return { type: x.type as any, name: x.name } as Ref;
+            });
+    }
+
     public async getLogEntries(
         pageIndex = 0,
         pageSize = 0,
@@ -176,6 +206,8 @@ export class Git implements IGitService {
 
         const count = parseInt(await this.exec(...args.counterArgs));
 
+        await this.loadDereferenceHashes();
+
         const items = output
             .split(LOG_ENTRY_SEPARATOR)
             .map(entry => {
@@ -187,12 +219,7 @@ export class Git implements IGitService {
             .filter(logEntry => logEntry !== undefined)
             .map(logEntry => {
                 // fill the refs from native git extension
-                logEntry!.refs = this.repo.state.refs
-                    .filter(x => x.commit === logEntry!.hash.full)
-                    .map(x => {
-                        return { type: x.type as any, name: x.name } as Ref;
-                    });
-
+                logEntry!.refs = this.getRefsContainingCommit(logEntry!.hash.full);
                 return logEntry!;
             });
 
@@ -217,7 +244,7 @@ export class Git implements IGitService {
         } as LogEntries;
     }
 
-    public async getCommit(hash: string): Promise<LogEntry | undefined> {
+    public async getCommit(hash: string, withRefs = false): Promise<LogEntry | undefined> {
         const commitArgs = this.gitArgsService.getCommitArgs(hash);
         const nameStatusArgs = this.gitArgsService.getCommitNameStatusArgsForMerge(hash);
 
@@ -247,7 +274,14 @@ export class Git implements IGitService {
             .filter(entry => entry !== undefined)
             .map(entry => entry!);
 
-        return entries.length > 0 ? entries[0] : undefined;
+        if (entries.length > 0) {
+            if (withRefs) {
+                entries[0].refs = this.getRefsContainingCommit(hash);
+            }
+            return entries[0];
+        }
+
+        return undefined;
     }
 
     @cache('IGitService')
@@ -340,11 +374,15 @@ export class Git implements IGitService {
     }
 
     public async createTag(tagName: string, hash: string): Promise<string> {
-        return this.exec('tag', '-a', tagName, '-m', tagName, hash);
+        const result = await this.exec('tag', '-a', tagName, '-m', tagName, hash);
+        // force git extension API to update repository refs
+        await this.repo.status();
+        return result;
     }
 
     public async removeTag(tagName: string) {
         await this.exec('tag', '-d', tagName);
+        this.refHashesMap.delete(tagName);
     }
 
     public async removeBranch(branchName: string) {

--- a/src/commandHandlers/commit/gitMerge.ts
+++ b/src/commandHandlers/commit/gitMerge.ts
@@ -23,9 +23,11 @@ export class GitMergeCommandHandler implements IGitMergeCommandHandler {
             .createGitService(commit.workspaceFolder);
         const currentBranch = await gitService.getCurrentBranch();
 
-        const commitBranches = (await gitService.getRefsContainingCommit(commit.logEntry.hash.full)).filter(
-            value => value.length > 0,
-        );
+        const commitBranches = gitService
+            .getRefsContainingCommit(commit.logEntry.hash.full)
+            .filter(value => value.name!.length > 0)
+            .map(x => x.name!);
+
         const branchMsg = `Choose the commit/branch to merge into ${currentBranch}`;
         const rev = await this.applicationShell.showQuickPick([commit.logEntry.hash.full, ...commitBranches], {
             placeHolder: branchMsg,

--- a/src/server/apiController.ts
+++ b/src/server/apiController.ts
@@ -119,7 +119,7 @@ export class ApiController {
                 await this.gitService.removeRemoteBranch(refEntry.name!);
         }
 
-        return this.gitService.getCommit(hash);
+        return this.gitService.getCommit(hash, true);
     }
     public async doAction(args: any) {
         const gitRoot = this.gitService.getGitRoot();

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface IGitService {
     getDetachedHash(): string | undefined;
     getBranches(): Promise<Branch[]>;
     getCurrentBranch(): Promise<string>;
-    getRefsContainingCommit(hash: string): Promise<string[]>;
+    getRefsContainingCommit(hash: string): Ref[];
     getLogEntries(
         pageIndex?: number,
         pageSize?: number,
@@ -148,7 +148,7 @@ export interface IGitService {
         author?: string,
     ): Promise<LogEntries>;
     getPreviousCommitHashForFile(hash: string, file: FsUri): Promise<Hash>;
-    getCommit(hash: string): Promise<LogEntry | undefined>;
+    getCommit(hash: string, withRefs?: boolean): Promise<LogEntry | undefined>;
     revertCommit(hash: string): Promise<void>;
     getCommitFile(hash: string, file: FsUri | string): Promise<Uri>;
     getDifferences(hash1: string, hash2: string): Promise<CommittedFile[]>;


### PR DESCRIPTION
This also fixed an issue where annotated tags are not being shown.

**Background info**

The git extension API provides an option to receive all repository related refs using `getAPI(1).repositories[0].state.refs`.

The git API returns the following for a single ref:

```
{
        "name": "1.0.0",
        "commit": "099eb26e234e6742bf000b756bc58ee8a8d4f8ba",
        "type": 2
    }
```

Unfortunately it does not take the annotated tags into account (intended or not) 
See [vscode/issues/92146](https://github.com/microsoft/vscode/issues/92146)

While the lightweight tag **correctly** refers to the related commit an annotation tag refers to a different hash and needs to be **dereferenced**.

To dereference an annotation tag the following command can be used:
```
git rev-parse 1.0.0^{}
```
