### PR TITLE
First implementation of a release github action

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,29 @@
+name: Generate Release Notes
+
+on:
+  create:
+    tags:
+      - v*
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - run: npm install github-release-notes -g
+    - name: Write PreRelease Notes
+      env:
+        GREN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gren release --override -P --tags=${{ github.event.ref }}
+    - name: Generate and Commit Changelog
+      env:
+        GREN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git fetch origin master
+        git checkout master
+        gren changelog --override
+        git -c user.name="ole1986" -c user.email="ole.k@web.de" commit -m "Updated CHANGELOG.md - Github Actions" -- CHANGELOG.md
+        git push origin master

--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,0 +1,18 @@
+
+function getAuthor(placeholders) {
+    if (placeholders.author === 'DonJayamanne') {
+        // skip owner
+        return '';
+    }
+    return `- ${placeholders.author ? `@${placeholders.author}` : name}`;
+}
+function parseCommitLine(placeholders) {
+    return `- [${placeholders.sha.substr(0, 7)}] ${placeholders.message} ${getAuthor(placeholders)}`
+}
+
+module.exports = {
+    dataSource: "commits",
+    "template": {
+        commit: parseCommitLine
+    }
+}


### PR DESCRIPTION
Finally with this PR a Github Action has been achieved to **prerelease** the version in github using `git tag vX.X.X` command

Steps to prerelease a version:

1. Make some changes to the source using another (inspiring) branch name
2. Create a pull request from the branch
3. Use the command `git tag v0.6.X` to create a new tag locally
4. Followed by the command `git push --tags origin`

This will save the changes between version v0.6.X and v0.6.X-1  into Github releases using `gren release`. Also, a CHANGELOG.md is being generated using `gren changelog` and pushed to master branch of the repository.
