### PR TITLE
Support fetching commits for more than 1 branch

### DIFF
--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -170,12 +170,13 @@ export class Git implements IGitService {
     public async getLogEntries(
         pageIndex = 0,
         pageSize = 0,
-        branch = '',
+        branches: string[] = [],
         searchText = '',
         file?: Uri,
         lineNumber?: number,
         author?: string,
     ): Promise<LogEntries> {
+        branches = Array.isArray(branches) ? branches : [];
         if (pageSize <= 0) {
             const workspace = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
             pageSize = workspace.getConfiguration('gitHistory').get<number>('pageSize', 100);
@@ -185,7 +186,7 @@ export class Git implements IGitService {
         const args = this.gitArgsService.getLogArgs(
             pageIndex,
             pageSize,
-            branch,
+            branches,
             searchText,
             relativePath,
             lineNumber,
@@ -227,7 +228,7 @@ export class Git implements IGitService {
         return {
             items,
             count,
-            branch,
+            branches,
             file,
             pageIndex,
             pageSize,

--- a/src/adapter/repository/gitArgsService.ts
+++ b/src/adapter/repository/gitArgsService.ts
@@ -43,14 +43,14 @@ export class GitArgsService implements IGitArgsService {
     public getLogArgs(
         pageIndex = 0,
         pageSize = 100,
-        branch = '',
+        branches: string[] = [],
         searchText = '',
         relativeFilePath?: string,
         lineNumber?: number,
         author?: string,
     ): GitLogArgs {
-        const allBranches = branch.trim().length === 0;
-        const currentBranch = branch.trim() === '*';
+        const allBranches = branches.length === 0;
+        const currentBranch = branches.length === 1 && branches[0].trim() === '*';
         const specificBranch = !allBranches && !currentBranch;
 
         const authorArgs: string[] = [];
@@ -103,9 +103,9 @@ export class GitArgsService implements IGitArgsService {
         }
 
         if (specificBranch && lineArgs.length === 0) {
-            logArgs.push(branch);
-            fileStatArgs.push(branch);
-            counterArgs.push(branch);
+            logArgs.push(...branches);
+            fileStatArgs.push(...branches);
+            counterArgs.push(...branches);
         }
 
         // Check if we need a specific file

--- a/src/adapter/repository/types.ts
+++ b/src/adapter/repository/types.ts
@@ -19,7 +19,7 @@ export interface IGitArgsService {
     getLogArgs(
         pageIndex?: number,
         pageSize?: number,
-        branch?: string,
+        branches?: string[],
         searchText?: string,
         relativeFilePath?: string,
         lineNumber?: number,

--- a/src/server/apiController.ts
+++ b/src/server/apiController.ts
@@ -6,7 +6,7 @@ import { ICommandManager } from '../application/types/commandManager';
 import { IGitCommitViewDetailsCommandHandler } from '../commandHandlers/types';
 import { CommitDetails, FileCommitDetails } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
-import { Avatar, IGitService, IPostMessage, LogEntry, Ref, RefType } from '../types';
+import { Avatar, BranchSelection, IGitService, IPostMessage, LogEntry, Ref, RefType } from '../types';
 import { captureTelemetry } from '../common/telemetry';
 
 export class ApiController {
@@ -36,7 +36,9 @@ export class ApiController {
 
         const lineNumber: number | undefined = args.line ? parseInt(args.line, 10) : undefined;
 
-        const branch = args.branchName;
+        const branches: string[] = [];
+
+        if (args.branchSelection != BranchSelection.All) branches.push(args.branchName);
 
         let pageSize: number | undefined = args.pageSize ? parseInt(args.pageSize, 10) : undefined;
         // When getting history for a line, then always get 10 pages, cuz `git log -L` also spits out the diff, hence slow
@@ -51,7 +53,7 @@ export class ApiController {
         const entries = await this.gitService.getLogEntries(
             pageIndex,
             pageSize,
-            [branch],
+            branches,
             searchText,
             file,
             lineNumber,

--- a/src/server/apiController.ts
+++ b/src/server/apiController.ts
@@ -51,7 +51,7 @@ export class ApiController {
         const entries = await this.gitService.getLogEntries(
             pageIndex,
             pageSize,
-            branch,
+            [branch],
             searchText,
             file,
             lineNumber,

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export interface IGitService {
     getLogEntries(
         pageIndex?: number,
         pageSize?: number,
-        branch?: string,
+        branches?: string[],
         searchText?: string,
         file?: Uri,
         lineNumber?: number,

--- a/test/extension/branches.test.ts
+++ b/test/extension/branches.test.ts
@@ -168,7 +168,7 @@ describe('Branches', () => {
 
         await assertCurrentBranch(gitService, commonNameAcrossAll);
 
-        const logEntries = await gitService.getLogEntries(0, 100, commonNameAcrossAll);
+        const logEntries = await gitService.getLogEntries(0, 100, [commonNameAcrossAll]);
         assert.isOk(logEntries);
         assert.equal(logEntries.count, 406);
         assert.equal(logEntries.items.length, 100);


### PR DESCRIPTION
Part of #386 
This is the backend part that adds support for #386.
@ole1986 Once your done with the new material-ui for the dropdowns we can turn the branch dropdown into a multi-select dropdown

Here's a screenshot of it working (all we need to do is ensure the UI supports multiple branches - backend works and graphs work as expected).
Following screenshot is with two branches (`hardcoded` in backend).
<img width="331" alt="Screen Shot 2020-03-15 at 19 05 05" src="https://user-images.githubusercontent.com/1948812/76717409-818e6b00-66f0-11ea-99f2-c0af3eba68e1.png">
