### PR TITLE
Setting to display icon in scm toolbar or overflow menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,12 @@
                 {
                     "command": "git.viewHistory",
                     "group": "navigation",
-                    "when": "config.git.enabled && gitOpenRepositoryCount != 0"
+                    "when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitHistory.sourceCodeProviderIntegrationLocation == 'Inline'"
+                },
+                {
+                    "command": "git.viewHistory",
+                    "group": "inline",
+                    "when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitHistory.sourceCodeProviderIntegrationLocation == 'More Actions'"
                 }
             ],
             "scm/resourceState/context": [
@@ -359,6 +364,19 @@
                     ],
                     "scope": "window",
                     "description": "Output log information"
+                },
+                "gitHistory.sourceCodeProviderIntegrationLocation": {
+                    "type": "string",
+                    "enum": [
+                        "Inline",
+                        "More Actions"
+                    ],
+                    "enumDescriptions": [
+                        "Show the 'Git: View History' action on the title of SCM Providers",
+                        "Show the 'Git: View History' action in the 'More Actions...' menu on the title of SCM Providers"
+                    ],
+                    "default": "Inline",
+                    "description": "Specifies where the 'Git: View History' action appears on the title of SCM Providers."
                 }
             }
         }


### PR DESCRIPTION
v0.6.3 of this extension had the following in the changelog: `[868d8e0] Always display icon in scm toolbar (#520)`. I don't like always displaying the icon since it takes up a lot of the space in that view. The [`Git Graph` extension](https://github.com/mhutchie/vscode-git-graph) also does this but its icon can be toggled to the overflow menu via its settings. See its [`package.json` file](https://github.com/mhutchie/vscode-git-graph/blob/5a444b01107d2327980cd5623d4c89dce9bc7447/package.json#L771). This PR copies the settings approach from `Git Graph` (while changing some descriptions) to make the scm icon configurable.