### PR TITLE
Setting to always prompt for repository picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,6 +325,12 @@
             "type": "object",
             "title": "Git History",
             "properties": {
+                "gitHistory.alwaysPromptRepositoryPicker": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "window",
+                    "description": "Always prompt with repository picker when running Git History"
+                },
                 "gitHistory.hideCommitViewExplorer": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4850116/80015532-2eb78880-84d2-11ea-8cb8-debf9d09f148.png)

Of course picker should only appear when more than 1 repository is available

Maybe a good compromise for #496 