### PR TITLE
Fixed status icon path in browser view

### DIFF
--- a/browser/src/components/LogView/Commit/FileEntry/index.tsx
+++ b/browser/src/components/LogView/Commit/FileEntry/index.tsx
@@ -37,7 +37,7 @@ export class FileEntry extends React.Component<FileEntryProps> {
         }
         const style = {
             marginLeft: '0.3em',
-            backgroundImage: `url('vscode-resource://file//${window['extensionPath']}/resources/icons/${theme}/${icon}')`,
+            backgroundImage: `url(${window['extensionPath']}/resources/icons/${theme}/${icon})`,
             display: 'inline-block',
             height: '0.9em',
             width: '0.9em',

--- a/src/server/htmlViewer.ts
+++ b/src/server/htmlViewer.ts
@@ -92,7 +92,7 @@ export class HtmlViewer {
         <html>
             <head>
                 <style type="text/css"> html, body{ height:100%; width:100%; overflow:hidden; padding:0;margin:0; }</style>
-                <meta http-equiv="Content-Security-Policy" content="default-src 'self' http://localhost:* http://127.0.0.1:* vscode-resource: 'unsafe-inline' 'unsafe-eval'; img-src * vscode-resource:" />
+                <meta http-equiv="Content-Security-Policy" content="default-src 'self' http://localhost:* http://127.0.0.1:* vscode-resource: 'unsafe-inline' 'unsafe-eval';" />
                 <link rel='stylesheet' type='text/css' href='${this.getRelativeResource(
                     webview,
                     'dist/browser/bundle.css',
@@ -100,7 +100,7 @@ export class HtmlViewer {
             <title>Git History</title>
             <script type="text/javascript">
                 window['vscode'] = acquireVsCodeApi();
-                window['extensionPath'] = ${JSON.stringify(this.extensionPath)};
+                window['extensionPath'] = ${JSON.stringify(this.getRelativeResource(webview, '').toString())};
                 window['configuration'] = ${JSON.stringify(config)};
                 window['settings'] = ${JSON.stringify(settings)};
                 window['locale'] = '${env.language}';


### PR DESCRIPTION
This recovers the status icons usually displayed when opening a commit

![image](https://user-images.githubusercontent.com/4850116/87439631-4db94880-c5f1-11ea-9ae9-69fc3c24b3b5.png)
