### PR TITLE
support split show history and highlight filename

### DIFF
--- a/browser/src/components/LogView/Commit/FileEntry/index.tsx
+++ b/browser/src/components/LogView/Commit/FileEntry/index.tsx
@@ -70,6 +70,11 @@ export class FileEntry extends React.Component<FileEntryProps> {
 
         const oldFile = ''; //this.props.committedFile.oldRelativePath || '';
         const constFileMovementSymbol = ''; //this.props.committedFile.oldRelativePath ? ' => ' : '';
+        let fileName = this.props.committedFile.relativePath;
+        if (fileName.lastIndexOf('/') != -1) {
+            fileName = fileName.substr(fileName.lastIndexOf('/') + 1);
+        }
+        const fileNameClass = fileName == globalThis.fileName ? 'file-name-active' : 'file-name';
 
         return (
             <div className="diff-row">
@@ -78,7 +83,7 @@ export class FileEntry extends React.Component<FileEntryProps> {
                     {blocks}
                     {this.renderStatus()}
                     <div className="file-name-cnt">
-                        <span className="file-name" onClick={this.onSelect}>
+                        <span className={fileNameClass} onClick={this.onSelect}>
                             {oldFile}
                             {constFileMovementSymbol}
                             {this.props.committedFile.relativePath}

--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -497,6 +497,19 @@ a.file-name {
 	color: transparent;
 }
 
+.file-name-active {
+	display: inline-block;
+	padding-left: 0.5em;
+	color:#91b748;
+}
+
+a.file-name-active {
+	position: absolute;
+	top: 0;
+	left: 0;
+	color: transparent;
+}
+
 .file-name-cnt:hover .file-name , .file-name-cnt:hover .file-name {
 	text-decoration: underline;
 	cursor: pointer;

--- a/package.json
+++ b/package.json
@@ -344,7 +344,7 @@
                 },
                 "gitHistory.showFileHistorySplit": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "scope": "window",
                     "description": "Split show file history when file is active."
                 },

--- a/package.json
+++ b/package.json
@@ -163,6 +163,12 @@
                 "title": "Show folder view"
             }
         ],
+        "keybindings": [
+			{
+				"command": "git.viewFileHistory",
+				"key": "alt+h"
+			}
+		],
         "menus": {
             "commandPalette": [
                 {
@@ -335,6 +341,12 @@
                     "default": false,
                     "scope": "window",
                     "description": "Always prompt with repository picker when running Git History"
+                },
+                "gitHistory.showFileHistorySplit": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "window",
+                    "description": "Split show file history when file is active."
                 },
                 "gitHistory.hideCommitViewExplorer": {
                     "type": "boolean",

--- a/src/commandHandlers/gitHistory.ts
+++ b/src/commandHandlers/gitHistory.ts
@@ -104,6 +104,7 @@ export class GitHistoryCommandHandler implements IGitHistoryCommandHandler {
             column = ViewColumn.Two;
         }
 
-        this.commandManager.executeCommand('previewHtml', uri, column, title);
+        const fileName = fileUri != null ? path.basename(fileUri.fsPath) : null;
+        this.commandManager.executeCommand('previewHtml', uri, column, title, fileName);
     }
 }

--- a/src/server/htmlViewer.ts
+++ b/src/server/htmlViewer.ts
@@ -25,10 +25,10 @@ export class HtmlViewer {
     public dispose() {
         this.disposable.forEach(disposable => disposable.dispose());
     }
-    private onPreviewHtml = (uri: string, column: ViewColumn, title: string) => {
-        this.createHtmlView(Uri.parse(uri), column, title);
+    private onPreviewHtml = (uri: string, column: ViewColumn, title: string, fileName?: string) => {
+        this.createHtmlView(Uri.parse(uri), column, title, fileName);
     };
-    private async createHtmlView(uri: Uri, column: ViewColumn, title: string) {
+    private async createHtmlView(uri: Uri, column: ViewColumn, title: string, fileName?: string) {
         if (this.htmlView.has(uri.toString())) {
             // skip recreating a webview, when already exist
             // and reveal it in tab view
@@ -78,7 +78,7 @@ export class HtmlViewer {
             branchSelection,
         };
 
-        webviewPanel.webview.html = this.getHtmlContent(webviewPanel.webview, settings);
+        webviewPanel.webview.html = this.getHtmlContent(webviewPanel.webview, settings, fileName);
     }
 
     private getRelativeResource(webview: Webview, relativePath: string) {
@@ -86,7 +86,7 @@ export class HtmlViewer {
         return webview.asWebviewUri(Uri.file(path.join(this.extensionPath, relativePath)));
     }
 
-    private getHtmlContent(webview, settings) {
+    private getHtmlContent(webview, settings, fileName?: string) {
         const config = workspace.getConfiguration('gitHistory');
         return `<!DOCTYPE html>
         <html>
@@ -104,6 +104,7 @@ export class HtmlViewer {
                 window['configuration'] = ${JSON.stringify(config)};
                 window['settings'] = ${JSON.stringify(settings)};
                 window['locale'] = '${env.language}';
+                window['fileName'] = '${fileName}';
             </script>
             </head>
             <body>


### PR DESCRIPTION
This PR  has two features.
1. Split history view when:
    1. Active file and target show history file are the same.
    2. Set `gitHistory.showFileHistorySplit` as true(default is false). 
2. Bind shortcut alt+h to show file history.
3. Highlight target filename in history view.

Before:
![image](https://user-images.githubusercontent.com/27798227/93959350-0edf0600-fd8b-11ea-8ad6-28b7971e47a7.png)
After
![image](https://user-images.githubusercontent.com/27798227/93974853-085f8700-fda9-11ea-98ef-bebf100c77e1.png)



