### PR TITLE
Reduce height of commit history item.

### DIFF
--- a/browser/src/main.css
+++ b/browser/src/main.css
@@ -62,7 +62,7 @@ body {
 }
 
 .media.right .media-image {
-	margin: 0.8em 0.3em 0 0;
+	margin: 0 0.3em 0 0;
 }
 
 div.appRootParent {


### PR DESCRIPTION
I think the current historical record is too high because of the margin on the right, so I removed his margin top.
Before:
![5I0F `YN{4 UKI1%R_U{NY](https://user-images.githubusercontent.com/27798227/110264826-21759080-7ff5-11eb-8a5f-83480f0a528d.png)
After
![E908XAIQY 1EZEMRPI62 X](https://user-images.githubusercontent.com/27798227/110264829-24708100-7ff5-11eb-8777-1b3a6b738f20.png)
