### PR TITLE
chore: upgrade vscode engine to 1.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.38.0"
+        "vscode": "^1.46.0"
     },
     "categories": [
         "Other"


### PR DESCRIPTION
the gitHistory used  `getBranches` of git API, It is from vscode@1.46.0, The engine should be ^1.46.0