### PR TITLE
use realpath to expand symlinks - Fixes #653

### DIFF
--- a/src/adapter/repository/factory.ts
+++ b/src/adapter/repository/factory.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { QuickPickItem, Uri } from 'vscode';
@@ -87,11 +88,12 @@ export class GitServiceFactory implements IGitServiceFactory {
         }
 
         if (resourceUri) {
+            const realResourcePath: string = fs.realpathSync(resourceUri!.fsPath);
             // find the correct repository from the given resource uri
             let i = 0;
             for (const x of gitApi.repositories) {
                 if (
-                    resourceUri!.fsPath.startsWith(x.rootUri.fsPath) &&
+                    realResourcePath.startsWith(x.rootUri.fsPath) &&
                     x.rootUri.fsPath === gitApi.repositories[i].rootUri.fsPath
                 ) {
                     this.repoIndex = i;

--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -45,7 +45,8 @@ export class Git implements IGitService {
             return file.fsPath;
         }
         const gitRoot: string = this.getGitRoot();
-        return path.relative(gitRoot, file.fsPath).replace(/\\/g, '/');
+        const filerealpath: string = fs.realpathSync(file.fsPath);
+        return path.relative(gitRoot, filerealpath).replace(/\\/g, '/');
     }
     public getHeadHashes(): { ref?: string; hash?: string }[] {
         return this.repo.state.refs


### PR DESCRIPTION
Proposed solution to #653 

Currently, if you open a file behind a symlink, the repo isn't detected because the file path (with symlink) differs from the repo working tree (expanded). Also, when the relative path is calculated, it causes an error stating that the file is not in the repository.

Expanding the file path with realpath before comparing to the working tree, and before calculating the relative path fixes the issue. 