### PR TITLE
Remote branch option

### DIFF
--- a/browser/src/components/Header/branch/index.tsx
+++ b/browser/src/components/Header/branch/index.tsx
@@ -3,7 +3,7 @@ import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { ResultActions } from '../../../actions/results';
 import { RootState, BranchesState } from '../../../reducers/index';
-import { BranchSelection, ISettings } from '../../../types';
+import { BranchSelection, ISettings, RefType } from '../../../types';
 
 interface BranchProps {
     isLoading?: boolean;
@@ -83,21 +83,24 @@ export class Branch extends React.Component<BranchProps, BranchState> {
             branches = branches.filter(x => x.name.toLowerCase().indexOf(this.state.searchText.toLowerCase()) !== -1);
         }
 
-        return branches.map(branch => {
-            if (branch.name === selectedBranch) {
-                return (
-                    <MenuItem key={branch.name} active eventKey={branch.name}>
-                        {branch.name}
-                    </MenuItem>
-                );
-            } else {
-                return (
-                    <MenuItem key={branch.name} eventKey={branch.name}>
-                        {branch.name}
-                    </MenuItem>
-                );
-            }
-        });
+        const localBranches = branches
+            .filter(p => p.type != RefType.RemoteHead)
+            .map(branch => (
+                <MenuItem key={branch.name} active={branch.name === selectedBranch} eventKey={branch.name}>
+                    {branch.name}
+                </MenuItem>
+            ));
+        const remoteBranches = branches
+            .filter(p => p.type == RefType.RemoteHead)
+            .map(branch => (
+                <MenuItem key={branch.name} active={branch.name === selectedBranch} eventKey={branch.name}>
+                    {branch.name}
+                </MenuItem>
+            ));
+
+        return remoteBranches.length > 0
+            ? localBranches.concat([<MenuItem divider>Remotes</MenuItem>]).concat(remoteBranches)
+            : localBranches;
     }
 
     private onClick = (e: React.MouseEvent<any, MouseEvent>) => {

--- a/browser/src/reducers/index.ts
+++ b/browser/src/reducers/index.ts
@@ -1,6 +1,6 @@
 import { routerReducer as routing } from 'react-router-redux';
 import { combineReducers } from 'redux';
-import { ActionedUser, Avatar, ISettings, LogEntriesResponse } from '../definitions';
+import { ActionedUser, Avatar, ISettings, LogEntriesResponse, RefType } from '../definitions';
 import authors from './authors';
 import avatars from './avatars';
 import branches from './branches';
@@ -14,7 +14,7 @@ export type LogEntriesState = LogEntriesResponse & {
     isLoadingCommit?: string;
 };
 
-export type BranchesState = { name: string; current: boolean; remote: string; remoteType: number }[];
+export type BranchesState = { name: string; type: RefType; current: boolean; remote: string; remoteType: number }[];
 export type AuthorsState = ActionedUser[];
 export type AvatarsState = Avatar[];
 export type RootState = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "githistory",
-    "version": "0.6.17",
+    "version": "0.6.18",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -721,9 +721,9 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -2042,12 +2042,8 @@
                 },
                 "prismjs": {
                     "version": "1.17.1",
-                    "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-                    "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-                    "dev": true,
-                    "requires": {
-                        "clipboard": "^2.0.0"
-                    }
+                    "resolved": "",
+                    "dev": true
                 },
                 "react-popper": {
                     "version": "1.3.11",
@@ -5562,12 +5558,12 @@
             "dev": true
         },
         "axios": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.10.0"
+                "follow-redirects": "^1.14.0"
             }
         },
         "babel-code-frame": {
@@ -7750,18 +7746,6 @@
             "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
             "dev": true
         },
-        "clipboard": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-            "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "good-listener": "^1.2.2",
-                "select": "^1.1.2",
-                "tiny-emitter": "^2.0.0"
-            }
-        },
         "cliui": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -7773,9 +7757,9 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
@@ -8334,9 +8318,9 @@
                     }
                 },
                 "tar": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
-                    "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+                    "version": "6.1.11",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+                    "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
                     "dev": true,
                     "requires": {
                         "chownr": "^2.0.0",
@@ -8967,13 +8951,6 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
-        },
-        "delegate": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-            "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-            "dev": true,
-            "optional": true
         },
         "delegates": {
             "version": "1.0.0",
@@ -10593,9 +10570,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-            "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
             "dev": true
         },
         "for-in": {
@@ -10821,8 +10798,7 @@
                 },
                 "ini": {
                     "version": "1.3.5",
-                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                    "resolved": "",
                     "dev": true,
                     "optional": true
                 },
@@ -11397,16 +11373,6 @@
                 }
             }
         },
-        "good-listener": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-            "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "delegate": "^3.1.2"
-            }
-        },
         "graceful-fs": {
             "version": "4.2.3",
             "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -11425,8 +11391,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                    "resolved": ""
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
@@ -12092,40 +12057,59 @@
             }
         },
         "inquirer": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-            "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
             "dev": true,
             "requires": {
                 "ansi-escapes": "^4.2.1",
-                "chalk": "^2.4.2",
+                "chalk": "^4.1.0",
                 "cli-cursor": "^3.1.0",
-                "cli-width": "^2.0.0",
+                "cli-width": "^3.0.0",
                 "external-editor": "^3.0.3",
                 "figures": "^3.0.0",
-                "lodash": "^4.17.15",
+                "lodash": "^4.17.19",
                 "mute-stream": "0.0.8",
-                "run-async": "^2.2.0",
-                "rxjs": "^6.5.3",
+                "run-async": "^2.4.0",
+                "rxjs": "^6.6.0",
                 "string-width": "^4.1.0",
-                "strip-ansi": "^5.1.0",
+                "strip-ansi": "^6.0.0",
                 "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-escapes": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-                    "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
                     "dev": true,
                     "requires": {
-                        "type-fest": "^0.8.1"
+                        "type-fest": "^0.21.3"
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
                 },
                 "cli-cursor": {
                     "version": "3.1.0",
@@ -12135,6 +12119,27 @@
                     "requires": {
                         "restore-cursor": "^3.1.0"
                     }
+                },
+                "cli-width": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+                    "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
@@ -12151,6 +12156,12 @@
                         "escape-string-regexp": "^1.0.5"
                     }
                 },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -12164,9 +12175,9 @@
                     "dev": true
                 },
                 "onetime": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+                    "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
                     "dev": true,
                     "requires": {
                         "mimic-fn": "^2.1.0"
@@ -12182,44 +12193,49 @@
                         "signal-exit": "^3.0.2"
                     }
                 },
+                "rxjs": {
+                    "version": "6.6.7",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+                    "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.9.0"
+                    }
+                },
                 "string-width": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
                     "dev": true,
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "6.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^5.0.0"
-                            }
-                        }
+                        "strip-ansi": "^6.0.1"
                     }
                 },
                 "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                            "dev": true
-                        }
+                        "ansi-regex": "^5.0.1"
                     }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
                 }
             }
         },
@@ -12970,8 +12986,7 @@
                 },
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "resolved": "",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -13440,8 +13455,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "resolved": "",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -13679,9 +13693,9 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -13922,9 +13936,9 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -14362,9 +14376,9 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -14460,9 +14474,9 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -14566,9 +14580,9 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -15193,8 +15207,7 @@
                 },
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "resolved": "",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -15435,9 +15448,9 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -17553,9 +17566,9 @@
             "dev": true
         },
         "nested-object-assign": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.3.tgz",
-            "integrity": "sha512-kgq1CuvLyUcbcIuTiCA93cQ2IJFSlRwXcN+hLcb2qLJwC2qrePHGZZa7IipyWqaWF6tQjdax2pQnVxdq19Zzwg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.4.tgz",
+            "integrity": "sha512-FlZ7oN9ICt+fbcJ4ag2IsALIcalfE/E16ttdSA8peBiHJI+oEKdOcafqDnUbeUe5NwWGn/m9zZGO9qrAGzfesg==",
             "dev": true
         },
         "next-tick": {
@@ -17765,9 +17778,9 @@
             }
         },
         "nth-check": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-            "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+            "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
             "dev": true,
             "requires": {
                 "boolbase": "^1.0.0"
@@ -18265,9 +18278,9 @@
             "dev": true
         },
         "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
         "path-to-regexp": {
@@ -18327,6 +18340,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "picocolors": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+            "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
             "dev": true
         },
         "picomatch": {
@@ -18468,25 +18487,13 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.27",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
-            "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+            "version": "7.0.39",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+            "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
             }
         },
         "postcss-calc": {
@@ -20261,9 +20268,9 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -20300,9 +20307,9 @@
             }
         },
         "prismjs": {
-            "version": "1.24.1",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-            "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+            "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
             "dev": true
         },
         "private": {
@@ -21477,14 +21484,14 @@
             "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
         },
         "refractor": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.4.0.tgz",
-            "integrity": "sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.5.0.tgz",
+            "integrity": "sha512-QwPJd3ferTZ4cSPPjdP5bsYHMytwWYnAN5EEnLtGvkqp/FCCnGsBgxrm9EuIDnjUC3Uc/kETtvVi7fSIVC74Dg==",
             "dev": true,
             "requires": {
                 "hastscript": "^6.0.0",
                 "parse-entities": "^2.0.0",
-                "prismjs": "~1.24.0"
+                "prismjs": "~1.25.0"
             }
         },
         "regenerate": {
@@ -22057,13 +22064,6 @@
                 "ajv-errors": "^1.0.0",
                 "ajv-keywords": "^3.1.0"
             }
-        },
-        "select": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-            "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-            "dev": true,
-            "optional": true
         },
         "semver": {
             "version": "5.7.1",
@@ -23207,13 +23207,6 @@
                 "setimmediate": "^1.0.4"
             }
         },
-        "tiny-emitter": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-            "dev": true,
-            "optional": true
-        },
         "tiny-invariant": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
@@ -23235,9 +23228,9 @@
             }
         },
         "tmpl": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
         "to-arraybuffer": {
@@ -23449,8 +23442,7 @@
                 },
                 "ansi-regex": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "resolved": "",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -24388,9 +24380,9 @@
             }
         },
         "url-parse": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-            "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+            "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
             "dev": true,
             "requires": {
                 "querystringify": "^2.1.1",
@@ -24979,12 +24971,12 @@
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.2 || 2"
+                "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "window-size": {
@@ -25025,9 +25017,9 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
                 },
                 "ansi-styles": {
                     "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -458,7 +458,7 @@
         "@types/vscode": "^1.46.0",
         "@typescript-eslint/eslint-plugin": "^2.21.0",
         "@typescript-eslint/parser": "^2.21.0",
-        "axios": "^0.21.1",
+        "axios": "^0.21.4",
         "babel-loader": "^8.0.6",
         "bootstrap": "^3.4.1",
         "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -335,6 +335,12 @@
                     "scope": "window",
                     "description": "Always prompt with repository picker when running Git History"
                 },
+                "gitHistory.includeRemoteBranches": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "resource",
+                    "description": "Include remote branches when opening Git History"
+                },
                 "gitHistory.showFileHistorySplit": {
                     "type": "boolean",
                     "default": true,

--- a/src/adapter/repository/git.ts
+++ b/src/adapter/repository/git.ts
@@ -83,6 +83,7 @@ export class Git implements IGitService {
                 return {
                     gitRoot: gitRoot,
                     name: r.name,
+                    type: r.type.valueOf(),
                     remote: remoteUrl,
                     remoteType: originType,
                     current: this.getCurrentBranch() === r.name,

--- a/src/adapter/repository/gitRemoteService.ts
+++ b/src/adapter/repository/gitRemoteService.ts
@@ -1,5 +1,4 @@
 import { Repository } from './git.d';
-import { Branch } from '../../types';
 import { IGitCommandExecutor } from '..';
 import { GitOriginType } from '.';
 import { captureTelemetry } from '../../common/telemetry';
@@ -8,30 +7,6 @@ export class GitRemoteService {
     constructor(private readonly repo: Repository, private readonly gitCmdExecutor: IGitCommandExecutor) {}
     private get currentBranch(): string {
         return this.repo.state.HEAD!.name || '';
-    }
-    @captureTelemetry()
-    public async getBranchesWithRemotes(): Promise<Branch[]> {
-        const gitRootPath = this.repo.rootUri.fsPath;
-        const branches: Branch[] = [];
-
-        await Promise.all(
-            this.repo.state.remotes.map(async remote => {
-                const branchNames = await this.getBranchesConfiguredForPullForRemote(remote.name);
-                await Promise.all(
-                    branchNames.map(async branchName => {
-                        branches.push({
-                            current: false,
-                            gitRoot: gitRootPath,
-                            name: branchName,
-                            remote: remote.fetchUrl!,
-                            remoteType: await this.getOriginType(remote.fetchUrl),
-                        });
-                    }),
-                );
-            }),
-        );
-
-        return branches;
     }
 
     public async getBranchesConfiguredForPullForRemote(remoteName: string): Promise<string[]> {

--- a/src/server/apiController.ts
+++ b/src/server/apiController.ts
@@ -8,10 +8,13 @@ import { CommitDetails, FileCommitDetails } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { Avatar, BranchSelection, CommittedFile, IGitService, IPostMessage, LogEntry, Ref, RefType } from '../types';
 import { captureTelemetry } from '../common/telemetry';
+import { IWorkspaceService } from '../application/types/workspace';
 
 export class ApiController {
     private readonly commitViewer: IGitCommitViewDetailsCommandHandler;
     private readonly applicationShell: IApplicationShell;
+    private workspace: IWorkspaceService;
+
     constructor(
         private webview: Webview,
         private gitService: IGitService,
@@ -22,6 +25,8 @@ export class ApiController {
             IGitCommitViewDetailsCommandHandler,
         );
         this.applicationShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+
+        this.workspace = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
 
         this.webview.onDidReceiveMessage(this.postMessageParser.bind(this));
     }
@@ -67,7 +72,9 @@ export class ApiController {
         };
     }
     public async getBranches() {
-        return this.gitService.getBranches();
+        return this.gitService.getBranches(
+            this.workspace.getConfiguration('gitHistory').get<boolean>('includeRemoteBranches', false),
+        );
     }
     public async getAuthors() {
         return this.gitService.getAuthors();

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type Remote = {
 export type Branch = {
     gitRoot: string;
     name: string;
+    type: RefType;
     remote: string;
     remoteType: GitOriginType | undefined;
     current: boolean;
@@ -136,7 +137,7 @@ export interface IGitService {
     getHeadHashes(): { ref?: string; hash?: string }[];
     getAuthors(): Promise<ActionedUser[]>;
     getDetachedHash(): string | undefined;
-    getBranches(): Promise<Branch[]>;
+    getBranches(withRemote?: boolean): Promise<Branch[]>;
     getCurrentBranch(): string;
     getRefsContainingCommit(hash: string): Ref[];
     getLogEntries(


### PR DESCRIPTION
A new configuration `gitHistory.includeRemoteBranches` (default: disabled) allowing us to display remote branches when opening "Git History"

The setting can either be configured per User or workspace (as usual)

![githistory-remote-branch](https://user-images.githubusercontent.com/4850116/127694292-273de1bd-34d1-4e8f-b091-03bf2e8c2217.gif)
