### PR TITLE
Fix "Open Repository on Github" not working on ssh remotes

### DIFF
--- a/browser/src/components/Header/index.tsx
+++ b/browser/src/components/Header/index.tsx
@@ -77,7 +77,13 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                     <a
                         className="hint--right hint--rounded hint--bounce"
                         aria-label="Open repository on Github"
-                        href={selectedBranch.remote.replace(/\.git$/, '') + '/tree/' + encodeURI(selectedBranch.name)}
+                        href={
+                            selectedBranch.remote
+                                .replace(/^git@github\.com:/, 'https://github.com/')
+                                .replace(/\.git$/, '') +
+                            '/tree/' +
+                            encodeURI(selectedBranch.name)
+                        }
                     >
                         <GoMarkGithub />
                     </a>


### PR DESCRIPTION
currently, when cloning a github repo using a ssh URL of this format `git@github.com:Company/repo-name.git` would break the _Open this Repository on Github_ button, because this URL will not be opend by the browser.

This PR replaces the URL with the corisponding `https://` URL so that the button againt takes the user to the github page.

```
git@github.com:Company/repo-name.git -> https://github.com/Company/repo-name.git
```