### PR TITLE
feat: quick compare previous commit

### DIFF
--- a/browser/src/components/LogView/LogEntry/index.tsx
+++ b/browser/src/components/LogView/LogEntry/index.tsx
@@ -126,6 +126,23 @@ class LogEntryView extends React.Component<ResultListProps, {}> {
                         <div className="buttons" onClick={() => this.props.onViewCommit(this.props.logEntry)}>
                             <div>
                                 <span
+                                    role="button"
+                                    className="btnx hint--top-left hint--rounded hint--bounce"
+                                    aria-label="Quick Compare file with previous commit"
+                                >
+                                    <a
+                                        role="button"
+                                        onClick={() => {
+                                            //Put the following function on the macro queue. after onViewCommit execute "getCommit" that micro queue，get the latest committedFiles field
+                                            setTimeout(() => {
+                                                this.props.onAction(this.props.logEntry, 'quick_compare_previous');
+                                            }, 0);
+                                        }}
+                                    >
+                                        quick look diff
+                                    </a>
+                                </span>
+                                <span
                                     onClick={e => copyText(e, this.props.logEntry.hash.full)}
                                     className="btnx hash clipboard hint--top-left hint--rounded hint--bounce"
                                     aria-label="Copy hash to clipboard"

--- a/browser/src/components/LogView/LogView/index.tsx
+++ b/browser/src/components/LogView/LogView/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ResultActions } from '../../../actions/results';
-import { LogEntry, Ref } from '../../../definitions';
+import { CommittedFile, LogEntry, Ref } from '../../../definitions';
 import { LogEntriesState, RootState } from '../../../reducers';
 import BranchGraph from '../BranchGraph';
 import LogEntryList from '../LogEntryList';
@@ -17,6 +17,7 @@ type LogViewProps = {
     actionRef: typeof ResultActions.actionRef;
     getPreviousCommits: typeof ResultActions.getPreviousCommits;
     getNextCommits: typeof ResultActions.getNextCommits;
+    actionFile: typeof ResultActions.actionFile;
 };
 
 interface LogViewState {}
@@ -149,6 +150,15 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
                     { entry, name },
                 );
                 break;
+            case 'quick_compare_previous':
+                this.props.actionFile(
+                    this.props.logEntries.selected,
+                    this.props.logEntries.selected.committedFiles.find(
+                        el => el.uri.fsPath === this.props.logEntries.file.fsPath,
+                    ),
+                    'compare_previous',
+                );
+                break;
             default:
                 this.props.actionCommit(entry, name);
                 break;
@@ -191,6 +201,9 @@ function mapDispatchToProps(dispatch) {
             dispatch(ResultActions.actionRef(logEntry, ref, name)),
         getNextCommits: () => dispatch(ResultActions.getNextCommits()),
         getPreviousCommits: () => dispatch(ResultActions.getPreviousCommits()),
+        actionFile: (logEntry: LogEntry, committedFile: CommittedFile, name) => {
+            dispatch(ResultActions.actionFile(logEntry, committedFile, name));
+        },
     };
 }
 

--- a/browser/src/components/LogView/LogView/index.tsx
+++ b/browser/src/components/LogView/LogView/index.tsx
@@ -154,7 +154,7 @@ class LogView extends React.Component<LogViewProps, LogViewState> {
                 this.props.actionFile(
                     this.props.logEntries.selected,
                     this.props.logEntries.selected.committedFiles.find(
-                        el => el.uri.fsPath === this.props.logEntries.file.fsPath,
+                        (el) => el.uri.fsPath === this.props.logEntries.file.fsPath,
                     ),
                     'compare_previous',
                 );


### PR DESCRIPTION
when user trigger "view line history" or "view file history". 
They need the following steps ：
1. select a commit
2. select a file from committedFiles ( In my opinion, I just want to see the current file ,No more search and clicks)
3. Choose several ways to compare different

There are so many processes, maybe has some way to quick  compare different 


